### PR TITLE
Escape forward slash in 'sed' execution for extended bin

### DIFF
--- a/src/rlx_prv_assembler.erl
+++ b/src/rlx_prv_assembler.erl
@@ -838,7 +838,7 @@ case \"$1\" in
         ROOTDIR=$RELEASE_ROOT_DIR
         BINDIR=$RELEASE_ROOT_DIR/erts-$ERTS_VSN/bin
         EMU=beam
-        PROGNAME=`echo $0 | sed 's/.*///'`
+        PROGNAME=`echo $0 | sed 's/.*\\///'`
         CMD=\"$BINDIR/erlexec $FOREGROUNDOPTIONS -boot $REL_DIR/$BOOTFILE -config $CONFIG_PATH -args_file $VMARGS_PATH\"
         export EMU
         export ROOTDIR


### PR DESCRIPTION
This is what currently happens without this fix:

```
$ bin/app foreground
sed: 1: "s/.*///": bad flag in substitute command: '/'
```
