### PR TITLE
add a dev mode that symlinks the release instead of copying it

### DIFF
--- a/src/relx.erl
+++ b/src/relx.erl
@@ -197,6 +197,8 @@ opt_spec_list() ->
       "Whether to use the default system added lib dirs (means you must add them all manually). Default is true"},
      {log_level, $V, "verbose", {integer, 2},
       "Verbosity level, maybe between 0 and 3"},
+     {dev_mode, $d, "dev-mode", {boolean, false},
+      "Symlink the applications and configuration into the release instead of copying"},
      {override_app, $a, "override_app", string,
       "Provide an app name and a directory to override in the form <appname>:<app directory>"},
      {config, $c, "config", {string, ""}, "The path to a config file"},

--- a/src/rlx_prv_config.erl
+++ b/src/rlx_prv_config.erl
@@ -105,7 +105,6 @@ parent_dir([_H], Acc) ->
 parent_dir([H | T], Acc) ->
     parent_dir(T, [H | Acc]).
 
-
 -spec load_config(file:filename(), rlx_state:t()) ->
                          {ok, rlx_state:t()} | relx:error().
 load_config(ConfigFile, State) ->
@@ -153,6 +152,8 @@ load_terms({skip_apps, SkipApps0}, {ok, State0}) ->
     {ok, rlx_state:skip_apps(State0, SkipApps0)};
 load_terms({overrides, Overrides0}, {ok, State0}) ->
     {ok, rlx_state:overrides(State0, Overrides0)};
+load_terms({dev_mode, DevMode}, {ok, State0}) ->
+    {ok, rlx_state:dev_mode(State0, DevMode)};
 load_terms({release, {RelName, Vsn}, Applications}, {ok, State0}) ->
     Release0 = rlx_release:new(RelName, Vsn),
     case rlx_release:goals(Release0, Applications) of

--- a/src/rlx_state.erl
+++ b/src/rlx_state.erl
@@ -61,6 +61,8 @@
          put/3,
          caller/1,
          caller/2,
+         dev_mode/1,
+         dev_mode/2,
          upfrom/1,
          format/1,
          format/2]).
@@ -88,6 +90,7 @@
                   skip_apps=[] :: [AppName::atom()],
                   configured_releases :: releases(),
                   realized_releases :: releases(),
+                  dev_mode=false :: boolean(),
                   upfrom :: string() | binary() | undefined,
                   config_values :: ec_dictionary:dictionary(Key::atom(),
                                                             Value::term())}).
@@ -209,7 +212,7 @@ vm_args(#state_t{vm_args=VmArgs}) ->
 
 -spec vm_args(t(), file:filename()) -> t().
 vm_args(State, VmArgs) ->
-	State#state_t{vm_args=VmArgs}.
+    State#state_t{vm_args=VmArgs}.
 
 -spec sys_config(t()) -> file:filename() | undefined.
 sys_config(#state_t{sys_config=SysConfig}) ->
@@ -316,6 +319,15 @@ caller(#state_t{caller=Caller}) ->
 -spec caller(t(), caller()) -> t().
 caller(S, Caller) ->
     S#state_t{caller=Caller}.
+
+-spec dev_mode(t()) -> boolean().
+dev_mode(#state_t{dev_mode=DevMode}) ->
+    DevMode.
+
+-spec dev_mode(t(), boolean()) -> t().
+dev_mode(S, DevMode) ->
+    S#state_t{dev_mode=DevMode}.
+
 
 -spec upfrom(t()) -> string() | binary() | undefined.
 upfrom(#state_t{upfrom=UpFrom}) ->


### PR DESCRIPTION
This should only ever be used for development, however it makes it
very, very nice to be able to simple recompile a project without
recopying it to try new things.
