### PR TITLE
patch for exception: no match of right hand side value

### DIFF
--- a/src/rlx_prv_config.erl
+++ b/src/rlx_prv_config.erl
@@ -191,9 +191,9 @@ load_terms({sys_config, SysConfig}, {ok, State}) ->
     {ok, rlx_state:sys_config(State, filename:absname(SysConfig))};
 load_terms({overlay_vars, OverlayVars}, {ok, State}) ->
     CurrentOverlayVars = rlx_state:get(State, overlay_vars),
-    NewOverlayVars = list_of_overlay_vars_files(OverlayVars),
-    NewOverlayVars = lists:umerge(lists:usort(NewOverlayVars), lists:usort(CurrentOverlayVars)),
-    {ok, rlx_state:put(State, overlay_vars, NewOverlayVars)};
+    NewOverlayVars0 = list_of_overlay_vars_files(OverlayVars),
+    NewOverlayVars1 = lists:umerge(lists:usort(NewOverlayVars0), lists:usort(CurrentOverlayVars)),
+    {ok, rlx_state:put(State, overlay_vars, NewOverlayVars1)};
 load_terms({Name, Value}, {ok, State})
   when erlang:is_atom(Name) ->
     {ok, rlx_state:put(State, Name, Value)};


### PR DESCRIPTION
Hi,
I was having an exception when using --overlay_vars.
Cheers.
