### PR TITLE
relx ignores -d (and --dev-mode) options

### DIFF
--- a/src/rlx_cmd_args.erl
+++ b/src/rlx_cmd_args.erl
@@ -300,8 +300,14 @@ create_paths(Opts, Acc) ->
             Error;
         ok ->
             code:add_pathsa([filename:absname(Path) || Path <- Dirs]),
-            {ok, Acc}
+            create_dev_mode(Opts, Acc)
     end.
+
+-spec create_dev_mode([getopt:option()], rlx_state:cmd_args()) ->
+                           {ok, rlx_state:cmd_args()} | relx:error().
+create_dev_mode(Opts, Acc) ->
+    DevMode = proplists:get_value(dev_mode, Opts, false),
+    {ok, [{dev_mode, DevMode} | Acc]}.
 
 -spec check_lib_dirs([string()]) -> ok | relx:error().
 check_lib_dirs([]) ->

--- a/src/rlx_state.erl
+++ b/src/rlx_state.erl
@@ -128,6 +128,7 @@ new(PropList, Targets)
                  output_dir=proplists:get_value(output_dir, PropList, ""),
                  lib_dirs=[to_binary(Dir) || Dir <- proplists:get_value(lib_dirs, PropList, [])],
                  config_file=proplists:get_value(config, PropList, undefined),
+                 dev_mode = proplists:get_value(dev_mode, PropList),
                  actions = Targets,
                  caller = Caller,
                  goals=proplists:get_value(goals, PropList, []),


### PR DESCRIPTION
If I don't have `{dev_mode, true}.` in the `relx.config` I never get the 

```
Dev mode enabled, release will be symlinked
```

message, no matter if I supply `--dev-mode` or not. If I put `{dev_mode, true}.` in the `relx.config` I always get it.

relx version 0.5.1
