### PR TITLE
Add option to skip release discovery

### DIFF
--- a/src/rlx_rel_discovery.erl
+++ b/src/rlx_rel_discovery.erl
@@ -38,12 +38,18 @@
 -spec do(rlx_state:t(), [file:name()], [rlx_app_info:t()]) ->
                 {ok, [rlx_release:t()]} | relx:error().
 do(State, LibDirs, AppMeta) ->
-    ec_cmd_log:info(rlx_state:log(State),
-                 fun() ->
-                         ["Resolving available OTP Releases from directories:\n",
-                          string:join([[rlx_util:indent(2), LibDir] || LibDir <- LibDirs], "\n")]
-                 end),
-    resolve_rel_metadata(State, LibDirs, AppMeta).
+    case rlx_state:get(State, disable_rel_discovery, false) of
+        true ->
+            ec_cmd_log:debug(rlx_state:log(State), "Disbaled resolving of OTP releases"),
+            {ok, []};
+        false ->
+            ec_cmd_log:info(rlx_state:log(State),
+                            fun() ->
+                                    ["Resolving available OTP Releases from directories:\n",
+                                     string:join([[rlx_util:indent(2), LibDir] || LibDir <- LibDirs], "\n")]
+                            end),
+            resolve_rel_metadata(State, LibDirs, AppMeta)
+    end.
 
 -spec format_error([ErrorDetail::term()]) -> iolist().
 format_error(ErrorDetails)

--- a/test/rlx_discover_SUITE.erl
+++ b/test/rlx_discover_SUITE.erl
@@ -110,10 +110,12 @@ no_beam_case(Config) ->
     AppDir = filename:join([LibDir2, BadName]),
     write_app_file(AppDir, BadName, BadVsn),
     State0 = proplists:get_value(state, Config),
-    {DiscoverProvider, {ok, State1}} = rlx_provider:new(rlx_prv_discover, State0),
+    %% Deliberately disable release discovery when running `rlx_prv_discover`
+    State1 = rlx_state:put(State0, disable_rel_discovery, true),
+    {DiscoverProvider, {ok, State2}} = rlx_provider:new(rlx_prv_discover, State1),
 
     ?assertMatch({ok, _},
-                 rlx_provider:do(DiscoverProvider, State1)).
+                 rlx_provider:do(DiscoverProvider, State2)).
 
 bad_ebin_case(Config) ->
     LibDir1 = proplists:get_value(lib1, Config),


### PR DESCRIPTION
`rlx_prv_discover` provider recursively scans all directories in
`lib_dirs` list looking for `*.app` and `*.rel` files.

This commit adds an option `disable_rel_discovery` to skip searching for
`*.rel` files when we know there aren't any. This speeds up release
generation with a lot of dependencies on the `libs_dir` list
significantly and reduces total release generation time in half.
