### PR TITLE
Enable cover in CT tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,6 +95,7 @@ ct: compile clean-common-test-data
 	-pa $(CURDIR)/deps/*/ebin \
 	-logdir $(CURDIR)/logs \
 	-dir $(CURDIR)/test/ \
+	-cover cover.spec \
 	-suite rlx_command_SUITE rlx_discover_SUITE -suite rlx_release_SUITE
 
 test: compile dialyzer eunit ct

--- a/cover.spec
+++ b/cover.spec
@@ -1,0 +1,2 @@
+%% -*- mode: Erlang; fill-column: 80; comment-column: 75; -*-
+{incl_app, relx, details}.


### PR DESCRIPTION
In addition to eunit coverage reports, one can look at coverage for each CT suite.
