### PR TITLE
Added a command line override for the sys_config setting.

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Options
 | -a    | --override_app | string | | An app name and a directory to override in the form appname:dir |
 | -c    | --config     | string  | ./relx.config | Config file path |
 |       | --overlay_vars     | string  |  | Path to a file of overlay variables |
+|       | --sys_config     | string  |  | Path to a file to use for sys.config |
 | -d    | --dev-mode     | boolean | false | Symlink all applications and configuration into the release instead of copying|
 Wiki
 ----

--- a/src/relx.erl
+++ b/src/relx.erl
@@ -203,6 +203,7 @@ opt_spec_list() ->
       "Provide an app name and a directory to override in the form <appname>:<app directory>"},
      {config, $c, "config", {string, ""}, "The path to a config file"},
      {overlay_vars, undefined, "overlay_vars", string, "Path to a file of overlay variables"},
+     {sys_config, undefined, "sys_config", string, "Path to a file to use for sys.config"},
      {system_libs, undefined, "system_libs", string, "Path to dir of Erlang system libs"},
      {version, undefined, "version", undefined, "Print relx version"},
      {root_dir, $r, "root", string, "The project root directory"}].

--- a/src/rlx_cmd_args.erl
+++ b/src/rlx_cmd_args.erl
@@ -253,7 +253,13 @@ create_disable_default_libs(Opts, Acc) ->
                                  {ok, rlx_state:cmd_args()} | relx:error().
 create_overlay_vars(Opts, Acc) ->
     OverlayVars = proplists:get_all_values(overlay_vars, Opts),
-    create_system_libs(Opts,  [{overlay_vars, OverlayVars} | Acc]).
+    create_sys_config(Opts,  [{overlay_vars, OverlayVars} | Acc]).
+
+-spec create_sys_config([getopt:option()], rlx_state:cmd_args()) ->
+                                 {ok, rlx_state:cmd_args()} | relx:error().
+create_sys_config(Opts, Acc) ->
+    SysConfig = proplists:get_value(sys_config, Opts, undefined),
+    create_system_libs(Opts, [{sys_config, SysConfig} | Acc]).
 
 -spec create_system_libs([getopt:option()], rlx_state:cmd_args()) ->
                                  {ok, rlx_state:cmd_args()} | relx:error().

--- a/src/rlx_prv_config.erl
+++ b/src/rlx_prv_config.erl
@@ -188,7 +188,12 @@ load_terms({release, {RelName, Vsn}, {erts, ErtsVsn},
 load_terms({vm_args, VmArgs}, {ok, State}) ->
     {ok, rlx_state:vm_args(State, filename:absname(VmArgs))};
 load_terms({sys_config, SysConfig}, {ok, State}) ->
-    {ok, rlx_state:sys_config(State, filename:absname(SysConfig))};
+    case rlx_state:sys_config(State) of
+        undefined ->
+            {ok, rlx_state:sys_config(State, filename:absname(SysConfig))};
+        _ ->
+            {ok, State}
+    end;
 load_terms({output_dir, OutputDir}, {ok, State}) ->
     {ok, rlx_state:output_dir(State, filename:absname(OutputDir))};
 load_terms({overlay_vars, OverlayVars}, {ok, State}) ->

--- a/src/rlx_state.erl
+++ b/src/rlx_state.erl
@@ -129,6 +129,7 @@ new(PropList, Targets)
                  output_dir=proplists:get_value(output_dir, PropList, ""),
                  lib_dirs=[to_binary(Dir) || Dir <- proplists:get_value(lib_dirs, PropList, [])],
                  config_file=proplists:get_value(config, PropList, undefined),
+                 sys_config=proplists:get_value(sys_config, PropList, undefined),
                  dev_mode = proplists:get_value(dev_mode, PropList),
                  actions = Targets,
                  caller = Caller,


### PR DESCRIPTION
Allows overriding the sys_config setting in relx.config via the command line with a --sys_config switch. Discussed in #122.
