### PR TITLE
Start scripts should honor existing LD_LIBRARY_PATH settings

### DIFF
--- a/src/rlx_prv_assembler.erl
+++ b/src/rlx_prv_assembler.erl
@@ -708,7 +708,7 @@ export ROOTDIR=$RELEASE_ROOT_DIR
 export BINDIR=$ERTS_DIR/bin
 export EMU=beam
 export PROGNAME=erl
-export LD_LIBRARY_PATH=$ERTS_DIR/lib
+export LD_LIBRARY_PATH=$ERTS_DIR/lib:$LD_LIBRARY_PATH
 
 cd $ROOTDIR
 
@@ -805,7 +805,7 @@ export ROOTDIR=$RELEASE_ROOT_DIR
 export BINDIR=$ERTS_DIR/bin
 export EMU=beam
 export PROGNAME=erl
-export LD_LIBRARY_PATH=$ERTS_DIR/lib
+export LD_LIBRARY_PATH=$ERTS_DIR/lib:$LD_LIBRARY_PATH
 
 cd $ROOTDIR
 


### PR DESCRIPTION
The start scripts export the LD_LIBRARY_PATH environment variable to "$ERTS_DIR/lib". They should honor existing LD_LIBRARY_PATH required e.g. for running ports.
