### PR TITLE
breaking change: output release to <output_dir>/<release_name>/

### DIFF
--- a/src/rlx_prv_config.erl
+++ b/src/rlx_prv_config.erl
@@ -200,7 +200,7 @@ load_terms({sys_config, SysConfig}, {ok, State}) ->
             {ok, State}
     end;
 load_terms({output_dir, OutputDir}, {ok, State}) ->
-    {ok, rlx_state:output_dir(State, filename:absname(OutputDir))};
+    {ok, rlx_state:base_output_dir(State, filename:absname(OutputDir))};
 load_terms({overlay_vars, OverlayVars}, {ok, State}) ->
     CurrentOverlayVars = rlx_state:get(State, overlay_vars),
     NewOverlayVars0 = list_of_overlay_vars_files(OverlayVars),

--- a/src/rlx_state.erl
+++ b/src/rlx_state.erl
@@ -26,8 +26,9 @@
 -export([new/2,
          log/1,
          actions/1,
-         output_dir/1,
-         output_dir/2,
+         output_dir/1,         
+         base_output_dir/1,
+         base_output_dir/2,
          lib_dirs/1,
          add_lib_dirs/2,
          overrides/1,
@@ -185,11 +186,16 @@ log(#state_t{log=LogState}) ->
     LogState.
 
 -spec output_dir(t()) -> file:name().
-output_dir(#state_t{output_dir=OutDir}) ->
+output_dir(State=#state_t{output_dir=OutDir}) ->
+    {RelName, _RelVsn} = default_configured_release(State),
+    filename:join(OutDir, RelName).
+
+-spec base_output_dir(t()) -> file:name().
+base_output_dir(#state_t{output_dir=OutDir}) ->
     OutDir.
 
--spec output_dir(t(), Directory::file:filename()) -> t().
-output_dir(State, Directory) ->
+-spec base_output_dir(t(), Directory::file:filename()) -> t().
+base_output_dir(State, Directory) ->
     State#state_t{output_dir=Directory}.
 
 -spec lib_dirs(t()) -> [file:name()].

--- a/test/rlx_command_SUITE.erl
+++ b/test/rlx_command_SUITE.erl
@@ -63,7 +63,7 @@ normal_passing_case(Config) ->
     {ok, State} = rlx_cmd_args:args2state(Opts, Targets),
     ?assertMatch([Lib1, Lib2],
                  rlx_state:lib_dirs(State)),
-    ?assertMatch(Outdir, rlx_state:output_dir(State)),
+    ?assertMatch(Outdir, rlx_state:base_output_dir(State)),
 
     ?assertMatch([{app1,{{33,33},{[],[<<"build4">>]}},lte},
                   {app2,

--- a/test/rlx_release_SUITE.erl
+++ b/test/rlx_release_SUITE.erl
@@ -267,7 +267,7 @@ make_overridden_release(Config) ->
     ?assert(lists:member({goal_app_2, "0.0.1"}, AppSpecs)),
     ?assert(lists:member({OverrideAppName, OverrideVsn}, AppSpecs)),
     ?assert(lists:member({lib_dep_1, "0.0.1", load}, AppSpecs)),
-    {ok, Real} = file:read_link(filename:join([OutputDir, "lib",
+    {ok, Real} = file:read_link(filename:join([OutputDir, "foo", "lib",
                                                OverrideApp ++ "-" ++ OverrideVsn])),
     ?assertMatch(OverrideAppDir, Real).
 
@@ -485,7 +485,7 @@ make_rerun_overridden_release(Config) ->
     ?assert(lists:member({goal_app_2, "0.0.1"}, AppSpecs)),
     ?assert(lists:member({OverrideAppName, OverrideVsn}, AppSpecs)),
     ?assert(lists:member({lib_dep_1, "0.0.1", load}, AppSpecs)),
-    {ok, Real} = file:read_link(filename:join([OutputDir, "lib",
+    {ok, Real} = file:read_link(filename:join([OutputDir, "foo", "lib",
                                                OverrideApp ++ "-" ++ OverrideVsn])),
     ?assertMatch(OverrideAppDir, Real).
 
@@ -563,19 +563,19 @@ overlay_release(Config) ->
     ?assert(lists:member({goal_app_2, "0.0.1"}, AppSpecs)),
     ?assert(lists:member({lib_dep_1, "0.0.1", load}, AppSpecs)),
 
-    ?assert(ec_file:exists(filename:join(OutputDir, "fooo"))),
-    ?assert(ec_file:exists(filename:join([OutputDir, "foodir", "vars1.config"]))),
-    ?assert(ec_file:exists(filename:join([OutputDir, "yahoo", "vars1.config"]))),
-    io:format("DirFile ~p~n", [filename:join([OutputDir, SecondTestDir, TestDir, TestFile])]),
-    ?assert(ec_file:exists(filename:join([OutputDir, SecondTestDir, TestDir, TestFile]))),
+    ?assert(ec_file:exists(filename:join([OutputDir, "foo", "fooo"]))),
+    ?assert(ec_file:exists(filename:join([OutputDir, "foo", "foodir", "vars1.config"]))),
+    ?assert(ec_file:exists(filename:join([OutputDir, "foo", "yahoo", "vars1.config"]))),
+    ?assert(ec_file:exists(filename:join([OutputDir, "foo", SecondTestDir, TestDir, TestFile]))),
 
-    TemplateData = case file:consult(filename:join([OutputDir, "test_template_resolved"])) of
+    TemplateData = case file:consult(filename:join([OutputDir, "foo", "test_template_resolved"])) of
                        {ok, Details} ->
                            Details;
                        Error ->
                            erlang:throw({failed_to_consult, Error})
                    end,
-    {ok, ReadFileInfo} = file:read_file_info(filename:join([OutputDir, "test_template_resolved"])),
+    
+    {ok, ReadFileInfo} = file:read_file_info(filename:join([OutputDir, "foo", "test_template_resolved"])),
     ?assertEqual(8#100777, ReadFileInfo#file_info.mode),
 
     ?assertEqual(erlang:system_info(version),
@@ -610,9 +610,9 @@ overlay_release(Config) ->
                  proplists:get_value(lib_dep_1_link, TemplateData)),
     ?assertEqual("(3:debug)",
                  proplists:get_value(log, TemplateData)),
-    ?assertEqual(OutputDir,
+    ?assertEqual(filename:join(OutputDir, "foo"),
                  proplists:get_value(output_dir, TemplateData)),
-    ?assertEqual(OutputDir,
+    ?assertEqual(filename:join(OutputDir, "foo"),
                  proplists:get_value(target_dir, TemplateData)),
     ?assertEqual([],
                  proplists:get_value(overridden, TemplateData)),
@@ -917,14 +917,14 @@ make_dev_mode_release(Config) ->
                           OutputDir, ConfigFile),
     [{{foo, "0.0.1"}, _Release}] = ec_dictionary:to_list(rlx_state:realized_releases(State)),
 
-    ?assert(ec_file:is_symlink(filename:join([OutputDir, "lib", "non_goal_1-0.0.1"]))),
-    ?assert(ec_file:is_symlink(filename:join([OutputDir, "lib", "non_goal_2-0.0.1"]))),
-    ?assert(ec_file:is_symlink(filename:join([OutputDir, "lib", "goal_app_1-0.0.1"]))),
-    ?assert(ec_file:is_symlink(filename:join([OutputDir, "lib", "goal_app_2-0.0.1"]))),
-    ?assert(ec_file:is_symlink(filename:join([OutputDir, "lib", "lib_dep_1-0.0.1"]))),
-    ?assert(ec_file:is_symlink(filename:join([OutputDir, "releases", "0.0.1",
+    ?assert(ec_file:is_symlink(filename:join([OutputDir, "foo", "lib", "non_goal_1-0.0.1"]))),
+    ?assert(ec_file:is_symlink(filename:join([OutputDir, "foo", "lib", "non_goal_2-0.0.1"]))),
+    ?assert(ec_file:is_symlink(filename:join([OutputDir, "foo", "lib", "goal_app_1-0.0.1"]))),
+    ?assert(ec_file:is_symlink(filename:join([OutputDir, "foo", "lib", "goal_app_2-0.0.1"]))),
+    ?assert(ec_file:is_symlink(filename:join([OutputDir, "foo", "lib", "lib_dep_1-0.0.1"]))),
+    ?assert(ec_file:is_symlink(filename:join([OutputDir, "foo", "releases", "0.0.1",
                                               "sys.config"]))),
-    ?assert(ec_file:is_symlink(filename:join([OutputDir, "releases", "0.0.1",
+    ?assert(ec_file:is_symlink(filename:join([OutputDir, "foo", "releases", "0.0.1",
                                               "vm.args"]))).
 
 


### PR DESCRIPTION
Since this changes the output structure I think it means we need to release it as 1.0.0. So we should decide what else we might want for that as well.

This is needed for https://github.com/erlware/relx/issues/148
