### PR TITLE
Silence superfluous erlydtl warnings

### DIFF
--- a/src/rlx_prv_overlay.erl
+++ b/src/rlx_prv_overlay.erl
@@ -30,7 +30,7 @@
 
 -define(DIRECTORY_RE, ".*(\/|\\\\)$").
 
--define(ERLYDTL_COMPILE_OPTS, [report_warnings, return_errors, {auto_escape, false}]).
+-define(ERLYDTL_COMPILE_OPTS, [report_warnings, return_errors, {auto_escape, false}, {out_dir, false}]).
 
 -include("relx.hrl").
 


### PR DESCRIPTION
I saw one other issue related to this, but it was closed and I'm still seeing it, so I went digging, and found that we need to add `{out_dir, false}` to `ERLYDTL_COMPILE_OPTS`. I've been testing with this change all day and everything seems to be working as expected for me (with no warnings being generated).

Please let me know if there is some reason why we don't want this.

Thanks!
