### PR TITLE
remove quoting that breaks start scripts

### DIFF
--- a/priv/templates/bin.dtl
+++ b/priv/templates/bin.dtl
@@ -17,7 +17,8 @@ find_erts_dir() {
         ROOTDIR="$RELEASE_ROOT_DIR"
     else
         local erl="$(which erl)"
-        local erl_root=$("$erl" -noshell -eval "io:format(\"~s\", [code:root_dir()])." -s init stop)
+        code="io:format(\"~s\", [code:root_dir()])."
+        local erl_root="$("$erl" -noshell -eval "$code" -s init stop)"
         ERTS_DIR="$erl_root/erts-$ERTS_VSN"
         ROOTDIR="$erl_root"
     fi

--- a/priv/templates/extended_bin.dtl
+++ b/priv/templates/extended_bin.dtl
@@ -19,7 +19,8 @@ find_erts_dir() {
         ROOTDIR="$RELEASE_ROOT_DIR"
     else
         local erl="$(which erl)"
-        local erl_root=$("$erl" -noshell -eval "io:format(\"~s\", [code:root_dir()])." -s init stop)
+        code="io:format(\"~s\", [code:root_dir()])."
+        local erl_root="$("$erl" -noshell -eval "$code" -s init stop)"
         ERTS_DIR="$erl_root/erts-$ERTS_VSN"
         ROOTDIR="$erl_root"
     fi


### PR DESCRIPTION
This may break for some cases of spaces in paths. But the commit that added these quotes broke the more common case of no spaces, so I think the possible regression for the less common case is less important than undoing the regression for the common case.
