### PR TITLE
Run nodetool using results of find_erts_dir

### DIFF
--- a/priv/templates/extended_bin.dtl
+++ b/priv/templates/extended_bin.dtl
@@ -45,7 +45,7 @@ relx_gen_id() {
 # Control a node
 relx_nodetool() {
     command="$1"; shift
-    "erts-$ERTS_VSN/bin/escript" "$ROOTDIR/bin/nodetool" "$NAME_TYPE" "$NAME" \
+    "$ERTS_DIR/bin/escript" "$ROOTDIR/bin/nodetool" "$NAME_TYPE" "$NAME" \
                                  -setcookie "$COOKIE" "$command"
 }
 


### PR DESCRIPTION
Before this change, extended_bin.dtl assumes the release uses an
embedded erts release when calling nodetool, making any
nodetool-related functionality incompatible with the following
setting:

  {include_erts, false}

This change calls nodetool using the escript binary in the path
discovered in the find_erts_dir function.
