### PR TITLE
Ensure assembler copies the contents of symlinked dirs

### DIFF
--- a/src/rlx_prv_assembler.erl
+++ b/src/rlx_prv_assembler.erl
@@ -101,7 +101,7 @@ print_dev_mode(State) ->
 -spec create_output_dir(file:name()) ->
                                ok | {error, Reason::term()}.
 create_output_dir(OutputDir) ->
-    case filelib:is_dir(OutputDir) of
+    case ec_file:is_dir(OutputDir) of
         false ->
             case rlx_util:mkdir_p(OutputDir) of
                 ok ->
@@ -169,7 +169,7 @@ remove_symlink_or_directory(TargetDir) ->
         true ->
             ec_file:remove(TargetDir);
         false ->
-            case filelib:is_dir(TargetDir) of
+            case ec_file:is_dir(TargetDir) of
                 true ->
                     ok = ec_file:remove(TargetDir, [recursive]);
                 false ->
@@ -204,7 +204,7 @@ copy_directory(AppDir, TargetDir, IncludeSrc) ->
 copy_dir(AppDir, TargetDir, SubDir) ->
     SubSource = filename:join(AppDir, SubDir),
     SubTarget = filename:join(TargetDir, SubDir),
-    case filelib:is_dir(SubSource) of
+    case ec_file:is_dir(SubSource) of
         true ->
             ok = rlx_util:mkdir_p(SubTarget),
             case ec_file:copy(SubSource, SubTarget, [recursive]) of
@@ -371,7 +371,7 @@ include_erts(State, Release, OutputDir, RelDir) ->
             ErtsDir = filename:join([Prefix, "erts-" ++ ErtsVersion]),
             LocalErts = filename:join([OutputDir, "erts-" ++ ErtsVersion]),
             {OsFamily, _OsName} = os:type(),
-            case filelib:is_dir(ErtsDir) of
+            case ec_file:is_dir(ErtsDir) of
                 false ->
                     ?RLX_ERROR({specified_erts_does_not_exist, ErtsVersion});
                 true ->


### PR DESCRIPTION
Dependencies located within an umbrella project In Elixir 0.14.x, or dependencies located on disk, use symlinks to avoid the overhead of copying files which are local to your filesystem during compilation. This causes an issue when attempting to generate a release with relx because `filelib:is_dir/1` does not consider a symlink a directory, even when the symlink is pointing to a directory.

I have opened [a pull request on the erlware_commons](https://github.com/erlware/erlware_commons/pull/68) project which adds `ec_file:is_dir/1`. It leverages `file:read_file_info/1` instead of `file:read_link_info/1` to identify if a node is a directory.

This will ensure that Elixir projects built with Mix 0.14.x can leverage relx to perform OTP releases.
