### PR TITLE
make PIPE_DIR overridable

### DIFF
--- a/priv/templates/extended_bin.dtl
+++ b/priv/templates/extended_bin.dtl
@@ -9,7 +9,7 @@ REL_VSN="{{ rel_vsn }}"
 ERTS_VSN="{{ erts_vsn }}"
 REL_DIR="$RELEASE_ROOT_DIR/releases/$REL_VSN"
 ERL_OPTS="{{ erl_opts }}"
-PIPE_DIR="/tmp/erl_pipes/{{ rel_name }}/"
+PIPE_DIR="${PIPE_DIR:-/tmp/erl_pipes/{{ rel_name }}/}"
 RUNNER_LOG_DIR="${RUNNER_LOG_DIR:-$RELEASE_ROOT_DIR/log}"
 
 find_erts_dir() {


### PR DESCRIPTION
This is useful in environment where temporary files should be in a different location.
