### PR TITLE
fix bug in path script

### DIFF
--- a/priv/templates/extended_bin.dtl
+++ b/priv/templates/extended_bin.dtl
@@ -55,7 +55,7 @@ relx_nodetool() {
 
 # Run an escript in the node's environment
 relx_escript() {
-    shift; scriptpath="$1"
+    shift; scriptpath="$1"; shift
     export RELEASE_ROOT_DIR
 
     "$ERTS_DIR/bin/escript" "$ROOTDIR/$scriptpath" $@


### PR DESCRIPTION
reversed order on shift and variable assignment during testing, causing command not to work
