### PR TITLE
Add support for multiple nodes running the same release

### DIFF
--- a/priv/templates/extended_bin.dtl
+++ b/priv/templates/extended_bin.dtl
@@ -9,7 +9,6 @@ REL_VSN="{{ rel_vsn }}"
 ERTS_VSN="{{ erts_vsn }}"
 REL_DIR="$RELEASE_ROOT_DIR/releases/$REL_VSN"
 ERL_OPTS="{{ erl_opts }}"
-PIPE_DIR="${PIPE_DIR:-/tmp/erl_pipes/{{ rel_name }}/}"
 RUNNER_LOG_DIR="${RUNNER_LOG_DIR:-$RELEASE_ROOT_DIR/log}"
 
 find_erts_dir() {
@@ -121,6 +120,8 @@ case $NAME in
         NAME=$NAME@`hostname -f`
         ;;
 esac
+
+PIPE_DIR="${PIPE_DIR:-/tmp/erl_pipes/$NAME/}"
 
 # Extract the target cookie
 COOKIE_ARG="$(grep '^-setcookie' "$VMARGS_PATH")"


### PR DESCRIPTION
The extended start script uses the `release name` (instead of the `node name`) when generating the pipe directory for an Erlang node. This prevents users from "deploying" multiple (Erlang) nodes running the same (Erlang) release, which might come in handy in a dev environment.

By using the `node name` instead of the `release name`, one can deploy `{N}` dev nodes locally and still be able to attach to all of them. Currently, one can only attach to the last deployed dev node. The pipe directory of the `{N - 1}` first dev nodes get overwritten.
