### PR TITLE
Fix grep pattern for beam process

### DIFF
--- a/priv/templates/extended_bin.dtl
+++ b/priv/templates/extended_bin.dtl
@@ -187,16 +187,16 @@ case "$1" in
             Linux|Darwin|FreeBSD|DragonFly|NetBSD|OpenBSD)
                 # PID COMMAND
                 PID=$(ps ax -o pid= -o command=|
-                      grep "$SCRIPT_DIR/.*/[b]eam"|awk '{print $1}')
+                      grep "$RELEASE_ROOT_DIR/.*/[b]eam"|awk '{print $1}')
                 ;;
             SunOS)
                 # PID COMMAND
                 PID=$(ps -ef -o pid= -o args=|
-                      grep "$SCRIPT_DIR/.*/[b]eam"|awk '{print $1}')
+                      grep "$RELEASE_ROOT_DIR/.*/[b]eam"|awk '{print $1}')
                 ;;
             CYGWIN*)
                 # UID PID PPID TTY STIME COMMAND
-                PID=$(ps -efw|grep "$SCRIPT_DIR/.*/[b]eam"|awk '{print $2}')
+                PID=$(ps -efw|grep "$RELEASE_ROOT_DIR/.*/[b]eam"|awk '{print $2}')
                 ;;
         esac
         if ! relx_nodetool "stop"; then


### PR DESCRIPTION
The stop command does not wait for the node to completely stop because of bad grep pattern.
