### PR TITLE
Fix *bin_windows.dtl boot script path

### DIFF
--- a/priv/templates/bin_windows.dtl
+++ b/priv/templates/bin_windows.dtl
@@ -15,6 +15,7 @@
 
 @call :find_erts_dir
 @call :find_sys_config
+@call :set_boot_script_var
 
 @set rootdir=%release_root_dir%
 @set bindir=%erts_dir%\bin
@@ -33,7 +34,7 @@ cd %rootdir%
 @echo Rootdir=%converted_rootdir% >> "%erl_ini%"
 
 :: Start the release in an `erl` shell
-@%erl% %erl_opts% %sys_config% -boot "%rel_dir%\%rel_name%" %*
+@%erl% %erl_opts% %sys_config% -boot "%boot_script%" %*
 
 @goto :eof
 
@@ -71,5 +72,14 @@ cd %rootdir%
 @set possible_sys=%rel_dir%\sys.config
 @if exist "%possible_sys%" (
   @set sys_config=-config "%possible_sys%"
+)
+@goto :eof
+
+:: set boot_script variable
+:set_boot_script_var
+@if exist "%rel_dir%\%rel_name%.boot" (
+  @set boot_script=%rel_dir%\%rel_name%
+) else (
+  @set boot_script=%rel_dir%\start
 )
 @goto :eof

--- a/priv/templates/extended_bin_windows.dtl
+++ b/priv/templates/extended_bin_windows.dtl
@@ -29,11 +29,11 @@
 
 @call :find_erts_dir
 @call :find_sys_config
+@call :set_boot_script_var
 
 @set bindir=%erts_dir%\bin
 @set vm_args=%rel_dir%\vm.args
 @set progname=erl.exe
-@set boot_script=%rel_dir%\%rel_name%
 @set clean_boot_script=%release_root_dir%\bin\start_clean
 @set erlsrv="%bindir%\erlsrv.exe"
 @set epmd="%bindir%\epmd.exe"
@@ -54,11 +54,6 @@
 
 :: Write the erl.ini file to set up paths relative to this script
 @call :write_ini
-
-:: If a start.boot file is not present, copy one from the named .boot file
-@if not exist "%rel_dir%\start.boot" (
-  @copy "%rel_dir%\%rel_name%.boot" "%rel_dir%\start.boot" >nul
-)
 
 @if "%1"=="install" @goto install
 @if "%1"=="uninstall" @goto uninstall
@@ -108,6 +103,15 @@
 @set possible_sys=%rel_dir%\sys.config
 @if exist %possible_sys% (
   @set sys_config=-config %possible_sys%
+)
+@goto :eof
+
+:: set boot_script variable
+:set_boot_script_var
+@if exist "%rel_dir%\%rel_name%.boot" (
+  @set boot_script=%rel_dir%\%rel_name%
+) else (
+  @set boot_script=%rel_dir%\start
 )
 @goto :eof
 


### PR DESCRIPTION
Hi again,

This PR fixes the selection of the boot script file depending on the release distribution (from `_erl` or from `tar archive`).
It basically port the logic of shell scripts to the windows scripts.

Tested with both compressed and uncompressed releases and extended and non extended scripts.

Cheers,
syl20bnr
