### PR TITLE
Add relup provider to tar dependencies

### DIFF
--- a/src/rlx_prv_archive.erl
+++ b/src/rlx_prv_archive.erl
@@ -31,7 +31,7 @@
 -include("relx.hrl").
 
 -define(PROVIDER, tar).
--define(DEPS, [release]).
+-define(DEPS, [release, relup]).
 
 %%============================================================================
 %% API


### PR DESCRIPTION
Hi Tristan,

This PR fixes the wrong order of providers when one uses `relx relup tar`.

Cheers,
syl20bnr
