### PR TITLE
move back to using format_error/1

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -10,7 +10,7 @@
           {branch, "master"}}},
         {providers, ".*",
          {git, "https://github.com/tsloughter/providers.git",
-          {branch, "master"}}},
+          {branch, "format_error1"}}},
         {erlydtl, ".*",
          {git, "https://github.com/erlydtl/erlydtl.git",
           {tag, "0.9.0"}}},

--- a/src/relx.erl
+++ b/src/relx.erl
@@ -26,7 +26,7 @@
          do/7,
          do/8,
          do/9,
-         format_error/2,
+         format_error/1,
          opt_spec_list/0]).
 
 -export_type([error/0]).
@@ -216,18 +216,18 @@ opt_spec_list() ->
      {version, undefined, "version", undefined, "Print relx version"},
      {root_dir, $r, "root", string, "The project root directory"}].
 
--spec format_error(Reason::term(), rlx_state:t()) -> string().
-format_error({invalid_return_value, Provider, Value}, _) ->
+-spec format_error(Reason::term()) -> string().
+format_error({invalid_return_value, Provider, Value}) ->
     io_lib:format(lists:flatten([providers:format(Provider), " returned an invalid value ",
                                  io_lib:format("~p", [Value])]), []);
-format_error({opt_parse, {invalid_option, Opt}}, _) ->
+format_error({opt_parse, {invalid_option, Opt}}) ->
     io_lib:format("invalid option ~s~n", [Opt]);
-format_error({opt_parse, Arg}, _) ->
+format_error({opt_parse, Arg}) ->
     io_lib:format("~p~n", [Arg]);
-format_error({error, {relx, Reason}}, State) ->
-    format_error(Reason, State);
-format_error({error, {Module, Reason}}, State) ->
-    io_lib:format("~s~n", [Module:format_error(Reason, State)]).
+format_error({error, {relx, Reason}}) ->
+    format_error(Reason);
+format_error({error, {Module, Reason}}) ->
+    io_lib:format("~s~n", [Module:format_error(Reason)]).
 
 %%============================================================================
 %% internal api
@@ -305,13 +305,13 @@ usage() ->
 report_error(State, Error) ->
     case Error of
         {error, {relx, {opt_parse, _}}} ->
-            io:format(standard_error, format_error(Error, State), []),
+            io:format(standard_error, format_error(Error), []),
             usage();
        {error, {rlx_cmd_args, _}} ->
-            io:format(standard_error, format_error(Error, State), []),
+            io:format(standard_error, format_error(Error), []),
             usage();
         _ ->
-            io:format(standard_error, format_error(Error, State), [])
+            io:format(standard_error, format_error(Error), [])
     end,
     case rlx_state:caller(State) of
         command_line ->

--- a/src/rlx_app_discovery.erl
+++ b/src/rlx_app_discovery.erl
@@ -25,7 +25,7 @@
 -module(rlx_app_discovery).
 
 -export([do/2,
-         format_error/2]).
+         format_error/1]).
 
 -include("relx.hrl").
 
@@ -44,10 +44,10 @@ do(State, LibDirs) ->
                     end),
     resolve_app_metadata(State, LibDirs).
 
--spec format_error([ErrorDetail::term()], rlx_state:t()) -> iolist().
-format_error(ErrorDetails, State)
+-spec format_error([ErrorDetail::term()]) -> iolist().
+format_error(ErrorDetails)
   when erlang:is_list(ErrorDetails) ->
-    [[format_detail(ErrorDetail, State), "\n"] || ErrorDetail <- ErrorDetails].
+    [[format_detail(ErrorDetail), "\n"] || ErrorDetail <- ErrorDetails].
 
 %%%===================================================================
 %%% Internal Functions
@@ -85,10 +85,10 @@ get_app_metadata(State, LibDirs) ->
                             {ok, _} = AppMeta ->
                                 [AppMeta|Acc];
                             {warning, W} ->
-                                ec_cmd_log:warn(rlx_state:log(State), format_detail(W, State)),
+                                ec_cmd_log:warn(rlx_state:log(State), format_detail(W)),
                                 Acc;
                             {error, E} ->
-                                ec_cmd_log:error(rlx_state:log(State), format_detail(E, State)),
+                                ec_cmd_log:error(rlx_state:log(State), format_detail(E)),
                                 Acc;
                             _ ->
                                 Acc
@@ -111,7 +111,7 @@ resolve_app_metadata(State, LibDirs) ->
                  {error, _} ->
                      true;
                  {warning, W} ->
-                     ec_cmd_log:warn(rlx_state:log(State), format_detail(W, State)),
+                     ec_cmd_log:warn(rlx_state:log(State), format_detail(W)),
                      false;
                  _ ->
                      false
@@ -155,30 +155,30 @@ resolve_override(AppName, FileName0) ->
             {ok, rlx_app_info:link(App, true)}
     end.
 
--spec format_detail(ErrorDetail::term(), rlx_state:t()) -> iolist().
-format_detail({missing_beam_file, Module, BeamFile}, _) ->
+-spec format_detail(ErrorDetail::term()) -> iolist().
+format_detail({missing_beam_file, Module, BeamFile}) ->
     io_lib:format("Missing beam file ~p ~p", [Module, BeamFile]);
-format_detail({error, {invalid_override, AppName, FileName}}, _) ->
+format_detail({error, {invalid_override, AppName, FileName}}) ->
     io_lib:format("Override {~p, ~p} is not a valid OTP App. Perhaps you forgot to build it?",
                   [AppName, FileName]);
-format_detail({accessing, File, eaccess}, _) ->
+format_detail({accessing, File, eaccess}) ->
     io_lib:format("permission denied accessing file ~s", [File]);
-format_detail({accessing, File, Type}, _) ->
+format_detail({accessing, File, Type}) ->
     io_lib:format("error (~p) accessing file ~s", [Type, File]);
-format_detail({no_beam_files, EbinDir}, _) ->
+format_detail({no_beam_files, EbinDir}) ->
     io_lib:format("no beam files found in directory ~s", [EbinDir]);
-format_detail({not_a_directory, EbinDir}, _) ->
+format_detail({not_a_directory, EbinDir}) ->
     io_lib:format("~s is not a directory when it should be a directory", [EbinDir]);
-format_detail({unable_to_load_app, AppDir, _}, _) ->
+format_detail({unable_to_load_app, AppDir, _}) ->
     io_lib:format("Unable to load the application metadata from ~s", [AppDir]);
-format_detail({invalid_app_file, File}, _) ->
+format_detail({invalid_app_file, File}) ->
     io_lib:format("Application metadata file exists but is malformed: ~s",
                   [File]);
-format_detail({unversioned_app, AppDir, _AppName}, _) ->
+format_detail({unversioned_app, AppDir, _AppName}) ->
     io_lib:format("Application metadata exists but version is not available: ~s",
                   [AppDir]);
-format_detail({app_info_error, {Module, Detail}}, State) ->
-    Module:format_error(Detail, State).
+format_detail({app_info_error, {Module, Detail}}) ->
+    Module:format_error(Detail).
 
 -spec discover_dir([file:name()], directory | file) ->
                           {ok, rlx_app_info:t()} | {error, Reason::term()}.

--- a/src/rlx_app_info.erl
+++ b/src/rlx_app_info.erl
@@ -52,7 +52,7 @@
          library_deps/2,
          link/1,
          link/2,
-         format_error/2,
+         format_error/1,
          format/2,
          format/1]).
 
@@ -170,8 +170,8 @@ link(#app_info_t{link=Link}) ->
 link(AppInfo, NewLink) ->
     AppInfo#app_info_t{link=NewLink}.
 
--spec format_error(Reason::term(), rlx_state:t()) -> iolist().
-format_error({vsn_parse, AppName}, _) ->
+-spec format_error(Reason::term()) -> iolist().
+format_error({vsn_parse, AppName}) ->
     io_lib:format("Error parsing version for ~p",
                   [AppName]).
 

--- a/src/rlx_cmd_args.erl
+++ b/src/rlx_cmd_args.erl
@@ -22,7 +22,7 @@
 -module(rlx_cmd_args).
 
 -export([args2state/2,
-         format_error/2]).
+         format_error/1]).
 
 -include("relx.hrl").
 
@@ -48,10 +48,10 @@ args2state(Opts, Targets) ->
             Error
     end.
 
--spec format_error(Reason::term(), rlx_state:t()) -> iolist().
-format_error({invalid_targets, Targets}, _) ->
+-spec format_error(Reason::term()) -> iolist().
+format_error({invalid_targets, Targets}) ->
     io_lib:format("One config must be specified! not ~p~n", [Targets]);
-format_error({invalid_option_arg, Arg}, _) ->
+format_error({invalid_option_arg, Arg}) ->
     case Arg of
         {goals, Goal} ->
             io_lib:format("Invalid Goal argument -g ~p~n", [Goal]);
@@ -68,20 +68,20 @@ format_error({invalid_option_arg, Arg}, _) ->
         {path, Path} ->
             io_lib:format("Invalid code path argument -n ~p~n", [Path])
     end;
-format_error({invalid_config_file, Config}, _) ->
+format_error({invalid_config_file, Config}) ->
     io_lib:format("Invalid configuration file specified: ~p", [Config]);
-format_error({invalid_caller, Caller}, _) ->
+format_error({invalid_caller, Caller}) ->
     io_lib:format("Invalid caller specified: ~s", [Caller]);
-format_error({failed_to_parse, Spec}, _) ->
+format_error({failed_to_parse, Spec}) ->
     io_lib:format("Unable to parse spec ~s", [Spec]);
-format_error({failed_to_parse_override, QA}, _) ->
+format_error({failed_to_parse_override, QA}) ->
     io_lib:format("Failed to parse app override ~s", [QA]);
-format_error({not_directory, Dir}, _) ->
+format_error({not_directory, Dir}) ->
     io_lib:format("Library directory does not exist: ~s", [Dir]);
-format_error({invalid_log_level, LogLevel}, _) ->
+format_error({invalid_log_level, LogLevel}) ->
     io_lib:format("Invalid log level specified -V ~p, log level must be in the"
                  " range 0..3", [LogLevel]);
-format_error({invalid_target, Target}, _) ->
+format_error({invalid_target, Target}) ->
     io_lib:format("Invalid action specified: ~s", [Target]).
 
 %%%===================================================================

--- a/src/rlx_config.erl
+++ b/src/rlx_config.erl
@@ -25,7 +25,7 @@
 
 %% API
 -export([do/1,
-         format_error/2]).
+         format_error/1]).
 
 -include("relx.hrl").
 
@@ -46,11 +46,11 @@ do(State) ->
             load_config(ConfigFile, State)
     end.
 
--spec format_error(Reason::term(), rlx_state:t()) -> iolist().
-format_error({consult, ConfigFile, Reason}, _) ->
+-spec format_error(Reason::term()) -> iolist().
+format_error({consult, ConfigFile, Reason}) ->
     io_lib:format("Unable to read file ~s: ~s", [ConfigFile,
                                                  file:format_error(Reason)]);
-format_error({invalid_term, Term}, _) ->
+format_error({invalid_term, Term}) ->
     io_lib:format("Invalid term in config file: ~p", [Term]).
 
 %%%===================================================================

--- a/src/rlx_depsolver.erl
+++ b/src/rlx_depsolver.erl
@@ -76,7 +76,7 @@
 -module(rlx_depsolver).
 
 %% Public Api
--export([format_error/2,
+-export([format_error/1,
          format_roots/1,
          format_culprits/1,
          format_constraint/1,
@@ -326,9 +326,9 @@ filter_packages(PVPairs, RawConstraints) ->
 %% could not be satisfied
 -spec format_error({error, {unreachable_package, list()} |
                            {invalid_constraints, [constraint()]} |
-                           list()}, rlx_state:t()) -> iolist().
-format_error(Error, State) ->
-    rlx_depsolver_culprit:format_error(Error, State).
+                           list()}) -> iolist().
+format_error(Error) ->
+    rlx_depsolver_culprit:format_error(Error).
 
 %% @doc Return a formatted list of roots of the dependency trees which
 %% could not be satisified. These may also have versions attached.

--- a/src/rlx_depsolver_culprit.erl
+++ b/src/rlx_depsolver_culprit.erl
@@ -31,7 +31,7 @@
 -module(rlx_depsolver_culprit).
 
 -export([search/3,
-        format_error/2,
+        format_error/1,
         format_version/1,
         format_constraint/1,
         format_roots/1,
@@ -68,19 +68,19 @@ search(State, ActiveCons, [NewCon | Constraints]) ->
             search(State, [NewCon | ActiveCons], Constraints)
     end.
 
-format_error({error, {unreachable_package, AppName}}, _) ->
+format_error({error, {unreachable_package, AppName}}) ->
     ["Dependency ", format_constraint(AppName), " is specified as a dependency ",
      "but is not reachable by the system.\n"];
-format_error({error, {invalid_constraints, Constraints}}, _) ->
+format_error({error, {invalid_constraints, Constraints}}) ->
     ["Invalid constraint ", add_s(Constraints), " specified ",
      lists:foldl(fun(Con, "") ->
                          [io_lib:format("~p", [Con])];
                     (Con, Acc) ->
                          [io_lib:format("~p", [Con]), ", " | Acc]
                  end, "", Constraints)];
-format_error({error, Detail}, State) ->
-    format_error(Detail, State);
-format_error(Details, _) when erlang:is_list(Details) ->
+format_error({error, Detail}) ->
+    format_error(Detail);
+format_error(Details) when erlang:is_list(Details) ->
     ["Unable to solve constraints, the following solutions were attempted \n\n",
      [[format_error_path("    ", Detail)] || Detail <- Details]].
 

--- a/src/rlx_dscv_util.erl
+++ b/src/rlx_dscv_util.erl
@@ -25,7 +25,7 @@
 -module(rlx_dscv_util).
 
 -export([do/2,
-         format_error/2]).
+         format_error/1]).
 
 -include("relx.hrl").
 
@@ -54,8 +54,8 @@ do(ProcessDir, LibDirs) ->
                                                      ec_file:type(LibDir))
                                 end, LibDirs)).
 
--spec format_error([ErrorDetail::term()], rlx_state:t()) -> iolist().
-format_error(ErrorDetails, _)
+-spec format_error([ErrorDetail::term()]) -> iolist().
+format_error(ErrorDetails)
   when erlang:is_list(ErrorDetails) ->
     [[format_detail(ErrorDetail), "\n"] || ErrorDetail <- ErrorDetails].
 

--- a/src/rlx_prv_app_discover.erl
+++ b/src/rlx_prv_app_discover.erl
@@ -28,7 +28,7 @@
 
 -export([init/1,
          do/1,
-         format_error/2]).
+         format_error/1]).
 
 -include("relx.hrl").
 
@@ -66,8 +66,8 @@ do(State0) ->
 
 %% @doc this is here to comply with the signature. However, we do not actually
 %% produce any errors and so simply return an empty string.
--spec format_error(any(), rlx_state:t()) -> iolist().
-format_error(_, _) ->
+-spec format_error(any()) -> iolist().
+format_error(_) ->
     "".
 
 %%%===================================================================

--- a/src/rlx_prv_archive.erl
+++ b/src/rlx_prv_archive.erl
@@ -26,7 +26,7 @@
 
 -export([init/1,
          do/1,
-         format_error/2]).
+         format_error/1]).
 
 -include("relx.hrl").
 
@@ -57,13 +57,13 @@ do(State) ->
     OutputDir = rlx_state:output_dir(State),
     make_tar(State, Release, OutputDir).
 
-format_error({tar_unknown_generation_error, Module, Vsn}, _) ->
+format_error({tar_unknown_generation_error, Module, Vsn}) ->
     io_lib:format("Tarball generation error of ~s ~s",
                   [Module, Vsn]);
-format_error({tar_generation_warn, Module, Warnings}, _) ->
+format_error({tar_generation_warn, Module, Warnings}) ->
     io_lib:format("Tarball generation warnings for ~p : ~p",
                   [Module, Warnings]);
-format_error({tar_generation_error, Module, Errors}, _) ->
+format_error({tar_generation_error, Module, Errors}) ->
     io_lib:format("Tarball generation error for ~p reason ~p",
                   [Module, Errors]).
 

--- a/src/rlx_prv_assembler.erl
+++ b/src/rlx_prv_assembler.erl
@@ -26,7 +26,7 @@
 
 -export([init/1,
          do/1,
-         format_error/2]).
+         format_error/1]).
 
 -include("relx.hrl").
 
@@ -84,35 +84,35 @@ do(State) ->
             Error
     end.
 
--spec format_error(ErrorDetail::term(), rlx_state:t()) -> iolist().
-format_error({unresolved_release, RelName, RelVsn}, _) ->
+-spec format_error(ErrorDetail::term()) -> iolist().
+format_error({unresolved_release, RelName, RelVsn}) ->
     io_lib:format("The release has not been resolved ~p-~s", [RelName, RelVsn]);
-format_error({ec_file_error, AppDir, TargetDir, E}, _) ->
+format_error({ec_file_error, AppDir, TargetDir, E}) ->
     io_lib:format("Unable to copy OTP App from ~s to ~s due to ~p",
                   [AppDir, TargetDir, E]);
-format_error({config_does_not_exist, Path}, _) ->
+format_error({config_does_not_exist, Path}) ->
     io_lib:format("The config file specified for this release (~s) does not exist!",
                   [Path]);
-format_error({specified_erts_does_not_exist, ErtsVersion}, _) ->
+format_error({specified_erts_does_not_exist, ErtsVersion}) ->
     io_lib:format("Specified version of erts (~s) does not exist",
                   [ErtsVersion]);
-format_error({release_script_generation_error, RelFile}, _) ->
+format_error({release_script_generation_error, RelFile}) ->
     io_lib:format("Unknown internal release error generating the release file to ~s",
                   [RelFile]);
-format_error({release_script_generation_warning, Module, Warnings}, _) ->
+format_error({release_script_generation_warning, Module, Warnings}) ->
     ["Warnings generating release \s",
      rlx_util:indent(2), Module:format_warning(Warnings)];
-format_error({unable_to_create_output_dir, OutputDir}, _) ->
+format_error({unable_to_create_output_dir, OutputDir}) ->
     io_lib:format("Unable to create output directory (possible permissions issue): ~s",
                   [OutputDir]);
-format_error({release_script_generation_error, Module, Errors}, State) ->
+format_error({release_script_generation_error, Module, Errors}) ->
     ["Errors generating release \n",
-     rlx_util:indent(2), Module:format_error(Errors, State)];
-format_error({unable_to_make_symlink, AppDir, TargetDir, Reason}, _) ->
+     rlx_util:indent(2), Module:format_error(Errors)];
+format_error({unable_to_make_symlink, AppDir, TargetDir, Reason}) ->
     io_lib:format("Unable to symlink directory ~s to ~s because \n~s~s",
                   [AppDir, TargetDir, rlx_util:indent(2),
                    file:format_error(Reason)]);
-format_error({strip_release, Reason}, _) ->
+format_error({strip_release, Reason}) ->
     io_lib:format("Stripping debug info from release beam files failed becuase ~s",
                   [beam_lib:format_error(Reason)]).
 

--- a/src/rlx_prv_overlay.erl
+++ b/src/rlx_prv_overlay.erl
@@ -26,7 +26,7 @@
 
 -export([init/1,
          do/1,
-         format_error/2]).
+         format_error/1]).
 
 -define(DIRECTORY_RE, ".*(\/|\\\\)$").
 
@@ -66,40 +66,40 @@ do(State) ->
             ?RLX_ERROR({unresolved_release, RelName, RelVsn})
     end.
 
--spec format_error(ErrorDetail::term(), rlx_state:t()) -> iolist().
-format_error({unresolved_release, RelName, RelVsn}, _) ->
+-spec format_error(ErrorDetail::term()) -> iolist().
+format_error({unresolved_release, RelName, RelVsn}) ->
     io_lib:format("The release has not been resolved ~p-~s", [RelName, RelVsn]);
-format_error({ec_file_error, AppDir, TargetDir, E}, _) ->
+format_error({ec_file_error, AppDir, TargetDir, E}) ->
     io_lib:format("Unable to copy OTP App from ~s to ~s due to ~p",
                   [AppDir, TargetDir, E]);
-format_error({unable_to_read_varsfile, FileName, Reason}, _) ->
+format_error({unable_to_read_varsfile, FileName, Reason}) ->
     io_lib:format("Unable to read vars file (~s) for overlay due to: ~p",
                   [FileName, Reason]);
-format_error({overlay_failed, Errors}, State) ->
-    [[format_error(rlx_util:error_reason(Error), State), "\n"] || Error <- Errors];
-format_error({dir_render_failed, Dir, Error}, _) ->
+format_error({overlay_failed, Errors}) ->
+    [[format_error(rlx_util:error_reason(Error)), "\n"] || Error <- Errors];
+format_error({dir_render_failed, Dir, Error}) ->
     io_lib:format("rendering mkdir path failed ~s with ~p",
                   [Dir, Error]);
-format_error({unable_to_make_symlink, AppDir, TargetDir, Reason}, _) ->
+format_error({unable_to_make_symlink, AppDir, TargetDir, Reason}) ->
     io_lib:format("Unable to symlink directory ~s to ~s because \n~s~s",
                   [AppDir, TargetDir, rlx_util:indent(2),
                    file:format_error(Reason)]);
-format_error({copy_failed, FromFile, ToFile, Err}, _) ->
+format_error({copy_failed, FromFile, ToFile, Err}) ->
     io_lib:format("Unable to copy from ~s to ~s because of ~p",
                   [FromFile, ToFile, Err]);
-format_error({unable_to_write, ToFile, Reason}, _) ->
+format_error({unable_to_write, ToFile, Reason}) ->
     io_lib:format("Unable to write to ~s because ~p",
                   [ToFile, Reason]);
-format_error({unable_to_enclosing_dir, ToFile, Reason}, _) ->
+format_error({unable_to_enclosing_dir, ToFile, Reason}) ->
     io_lib:format("Unable to create enclosing directory for ~s because ~p",
                   [ToFile, Reason]);
-format_error({unable_to_render_template, FromFile, Reason}, _) ->
+format_error({unable_to_render_template, FromFile, Reason}) ->
     io_lib:format("Unable to render template ~s because ~p",
                   [FromFile, Reason]);
-format_error({unable_to_compile_template, FromFile, Reason}, State) ->
+format_error({unable_to_compile_template, FromFile, Reason}) ->
     io_lib:format("Unable to compile template ~s because \n~s",
-                  [FromFile, [format_errors(F, Es, State) || {F, Es} <- Reason]]);
-format_error({unable_to_make_dir, Absolute, Error}, _) ->
+                  [FromFile, [format_errors(F, Es) || {F, Es} <- Reason]]);
+format_error({unable_to_make_dir, Absolute, Error}) ->
     io_lib:format("Unable to make directory ~s because ~p",
                   [Absolute, Error]).
 
@@ -107,22 +107,22 @@ format_error({unable_to_make_dir, Absolute, Error}, _) ->
 %%% Internal Functions
 %%%===================================================================
 
-format_errors(File, [{none, Mod, E}|Es], State) ->
+format_errors(File, [{none, Mod, E}|Es]) ->
     [io_lib:format("~s~s: ~ts~n",
                    [rlx_util:indent(2), File,
-                    Mod:format_error(E, State)])
-     |format_errors(File, Es, State)];
-format_errors(File, [{{Line, Col}, Mod, E}|Es], State) ->
+                    Mod:format_error(E)])
+     |format_errors(File, Es)];
+format_errors(File, [{{Line, Col}, Mod, E}|Es]) ->
     [io_lib:format("~s~s:~w:~w: ~ts~n",
                    [rlx_util:indent(2), File, Line, Col,
-                    Mod:format_error(E, State)])
-     |format_errors(File, Es, State)];
-format_errors(File, [{Line, Mod, E}|Es], State) ->
+                    Mod:format_error(E)])
+     |format_errors(File, Es)];
+format_errors(File, [{Line, Mod, E}|Es]) ->
     [io_lib:format("~s~s:~w: ~ts~n",
                    [rlx_util:indent(2), File, Line,
-                    Mod:format_error(E, State)])
-     |format_errors(File, Es, State)];
-format_errors(_, [], _State) -> [].
+                    Mod:format_error(E)])
+     |format_errors(File, Es)];
+format_errors(_, []) -> [].
 
 
 -spec generate_overlay_vars(rlx_state:t(), rlx_release:t()) ->
@@ -168,7 +168,7 @@ merge_overlay_vars(State, FileNames) ->
                                 lists:ukeymerge(1, lists:ukeysort(1, Terms), Acc);
                             {error, Reason} ->
                                 ec_cmd_log:warn(rlx_state:log(State),
-                                                format_error({unable_to_read_varsfile, FileName, Reason}, State)),
+                                                format_error({unable_to_read_varsfile, FileName, Reason})),
                                 Acc
                         end
                 end, [], FileNames).

--- a/src/rlx_prv_rel_discover.erl
+++ b/src/rlx_prv_rel_discover.erl
@@ -23,7 +23,7 @@
 
 -export([init/1,
          do/1,
-         format_error/2]).
+         format_error/1]).
 
 -include("relx.hrl").
 
@@ -59,8 +59,8 @@ do(State0) ->
             Error
     end.
 
--spec format_error(any(), rlx_state:t()) -> iolist().
-format_error(_, _) ->
+-spec format_error(any()) -> iolist().
+format_error(_) ->
     "".
 
 %%%===================================================================

--- a/src/rlx_prv_release.erl
+++ b/src/rlx_prv_release.erl
@@ -24,7 +24,7 @@
 
 -export([init/1,
          do/1,
-         format_error/2]).
+         format_error/1]).
 
 -include("relx.hrl").
 
@@ -54,26 +54,26 @@ do(State) ->
     DepGraph = create_dep_graph(State),
     find_default_release(State, DepGraph).
 
--spec format_error(ErrorDetail::term(), rlx_state:t()) -> iolist().
-format_error(no_goals_specified, _) ->
+-spec format_error(ErrorDetail::term()) -> iolist().
+format_error(no_goals_specified) ->
     "No goals specified for this release ~n";
-format_error({no_release_name, Vsn}, _) ->
+format_error({no_release_name, Vsn}) ->
     io_lib:format("A target release version was specified (~s) but no name", [Vsn]);
-format_error({invalid_release_info, Info}, _) ->
+format_error({invalid_release_info, Info}) ->
     io_lib:format("Target release information is in an invalid format ~p", [Info]);
-format_error({multiple_release_names, RelA, RelB}, _) ->
+format_error({multiple_release_names, RelA, RelB}) ->
     io_lib:format("No default release name was specified and there are multiple "
                   "releases in the config: ~s, ~s",
                   [RelA, RelB]);
-format_error(no_releases_in_system, _) ->
+format_error(no_releases_in_system) ->
     "No releases have been specified in the system!";
-format_error({no_releases_for, RelName}, _) ->
+format_error({no_releases_for, RelName}) ->
     io_lib:format("No releases exist in the system for ~s!", [RelName]);
-format_error({release_not_found, {RelName, RelVsn}}, _) ->
+format_error({release_not_found, {RelName, RelVsn}}) ->
     io_lib:format("No releases exist in the system for ~p:~s!", [RelName, RelVsn]);
-format_error({failed_solve, Error}, State) ->
+format_error({failed_solve, Error}) ->
     io_lib:format("Failed to solve release:\n ~s",
-                  [rlx_depsolver:format_error({error, Error}, State)]).
+                  [rlx_depsolver:format_error({error, Error})]).
 
 %%%===================================================================
 %%% Internal Functions

--- a/src/rlx_prv_relup.erl
+++ b/src/rlx_prv_relup.erl
@@ -26,7 +26,7 @@
 
 -export([init/1,
          do/1,
-         format_error/2]).
+         format_error/1]).
 
 -include("relx.hrl").
 
@@ -55,24 +55,24 @@ do(State) ->
     Release0 = rlx_state:get_realized_release(State, RelName, RelVsn),
     make_relup(State, Release0).
 
-format_error({relup_generation_error, CurrentName, UpFromName}, _) ->
+format_error({relup_generation_error, CurrentName, UpFromName}) ->
     io_lib:format("Unknown internal release error generating the relup from ~s to ~s",
                   [UpFromName, CurrentName]);
-format_error({relup_generation_warning, Module, Warnings}, _) ->
+format_error({relup_generation_warning, Module, Warnings}) ->
     ["Warnings generating relup \s",
      rlx_util:indent(2), Module:format_warning(Warnings)];
-format_error({no_upfrom_release_found, undefined}, _) ->
+format_error({no_upfrom_release_found, undefined}) ->
     io_lib:format("No earlier release for relup found", []);
-format_error({no_upfrom_release_found, Vsn}, _) ->
+format_error({no_upfrom_release_found, Vsn}) ->
     io_lib:format("Upfrom release version (~s) for relup not found", [Vsn]);
 format_error({relup_script_generation_error,
               {relup_script_generation_error, systools_relup,
-               {missing_sasl, _}}}, _) ->
+               {missing_sasl, _}}}) ->
     "Unfortunately, due to requirements in systools, you need to have the sasl application "
         "in both the current release and the release to upgrade from.";
-format_error({relup_script_generation_error, Module, Errors}, State) ->
+format_error({relup_script_generation_error, Module, Errors}) ->
     ["Errors generating relup \n",
-     rlx_util:indent(2), Module:format_error(Errors, State)].
+     rlx_util:indent(2), Module:format_error(Errors)].
 
 make_relup(State, Release) ->
     Vsn = rlx_state:upfrom(State),

--- a/src/rlx_rel_discovery.erl
+++ b/src/rlx_rel_discovery.erl
@@ -21,7 +21,7 @@
 -module(rlx_rel_discovery).
 
 -export([do/3,
-         format_error/2]).
+         format_error/1]).
 
 -include("relx.hrl").
 
@@ -47,8 +47,8 @@ do(State, LibDirs, AppMeta) ->
             resolve_rel_metadata(State, LibDirs, AppMeta)
     end.
 
--spec format_error([ErrorDetail::term()], rlx_state:t()) -> iolist().
-format_error(ErrorDetails, _)
+-spec format_error([ErrorDetail::term()]) -> iolist().
+format_error(ErrorDetails)
   when erlang:is_list(ErrorDetails) ->
     [[format_detail(ErrorDetail), "\n"] || ErrorDetail <- ErrorDetails].
 

--- a/src/rlx_release.erl
+++ b/src/rlx_release.erl
@@ -41,7 +41,7 @@
          canonical_name/1,
          format/1,
          format/2,
-         format_error/2]).
+         format_error/1]).
 
 -export_type([t/0,
               name/0,
@@ -217,14 +217,14 @@ format_goal({Constraint, AppType, AppInc}) ->
 format_goal(Constraint) ->
     rlx_depsolver:format_constraint(Constraint).
 
--spec format_error(Reason::term(), rlx_state:t()) -> iolist().
-format_error({topo_error, E}, State) ->
-    rlx_topo:format_error(E, State);
-format_error({failed_to_parse, Con}, _) ->
+-spec format_error(Reason::term()) -> iolist().
+format_error({topo_error, E}) ->
+    rlx_topo:format_error(E);
+format_error({failed_to_parse, Con}) ->
     io_lib:format("Failed to parse constraint ~p", [Con]);
-format_error({invalid_constraint, _, Con}, _) ->
+format_error({invalid_constraint, _, Con}) ->
     io_lib:format("Invalid constraint specified ~p", [Con]);
-format_error({not_realized, Name, Vsn}, _) ->
+format_error({not_realized, Name, Vsn}) ->
     io_lib:format("Unable to produce metadata release: ~p-~s has not been realized",
                   [Name, Vsn]).
 

--- a/src/rlx_topo.erl
+++ b/src/rlx_topo.erl
@@ -34,7 +34,7 @@
 
 -export([sort/1,
          sort_apps/1,
-         format_error/2]).
+         format_error/1]).
 
 -include("relx.hrl").
 
@@ -72,8 +72,8 @@ sort(Pairs) ->
     iterate(Pairs, [], all(Pairs)).
 
 %% @doc nicely format the error from the sort.
--spec format_error(Reason::term(), rlx_state:t()) -> iolist().
-format_error({cycle, Pairs}, _) ->
+-spec format_error(Reason::term()) -> iolist().
+format_error({cycle, Pairs}) ->
     ["Cycle detected in dependency graph, this must be resolved "
      "before we can continue:\n",
     case Pairs of

--- a/test/rlx_depsolver_tests.erl
+++ b/test/rlx_depsolver_tests.erl
@@ -137,7 +137,7 @@ fail_test() ->
 
     Ret = rlx_depsolver:solve(Dom0, [{app1, "0.1"}]),
     %% We do this to make sure all errors can be formated.
-    _ = rlx_depsolver:format_error(Ret, []),
+    _ = rlx_depsolver:format_error(Ret),
     ?assertMatch({error,
                   [{[{[{app1,{{0,1},{[],[]}}}],
                       [{app1,{{0,1},{[],[]}}},[[{app2,{{0,2},{[],[]}}}]]]}],
@@ -215,7 +215,7 @@ conflicting_failing_test() ->
                                                                   {app5, [{"2.0.0", []},
                                                                           {"6.0.0", []}]}]),
     Ret = rlx_depsolver:solve(Dom0, [app1, app3]),
-    _ = rlx_depsolver:format_error(Ret, []),
+    _ = rlx_depsolver:format_error(Ret),
     ?assertMatch({error,
                   [{[{[app1],
                       [{app1,{{3,0},{[],[]}}},
@@ -351,7 +351,7 @@ filter_versions_test() ->
 
     Ret = rlx_depsolver:filter_packages(Packages,
                                         [{"foo", "1.0.0", '~~~~'} | Cons]),
-    _ = rlx_depsolver:format_error(Ret, []),
+    _ = rlx_depsolver:format_error(Ret),
     ?assertMatch({error, {invalid_constraints, [{<<"foo">>,{{1,0,0},{[],[]}},'~~~~'}]}}, Ret).
 
 
@@ -370,11 +370,11 @@ missing_test() ->
                                                                           {"0.2", []},
                                                                           {"0.3", []}]}]),
     Ret1 = rlx_depsolver:solve(Dom0, [{app4, "0.1"}, {app3, "0.1"}]),
-    _ = rlx_depsolver:format_error(Ret1, []),
+    _ = rlx_depsolver:format_error(Ret1),
     ?assertMatch({error,{unreachable_package,app4}}, Ret1),
 
     Ret2 = rlx_depsolver:solve(Dom0, [{app1, "0.1"}]),
-    _ = rlx_depsolver:format_error(Ret2, []),
+    _ = rlx_depsolver:format_error(Ret2),
     ?assertMatch({error,{unreachable_package,app4}},
                  Ret2).
 
@@ -387,7 +387,7 @@ binary_test() ->
                                                          World),
                               [<<"foo">>]),
 
-    _ = rlx_depsolver:format_error(Ret, []),
+    _ = rlx_depsolver:format_error(Ret),
     ?assertMatch({error,
                   [{[{[<<"foo">>],[{<<"foo">>,{{1,2,3},{[],[]}}}]}],
                     [{{<<"foo">>,{{1,2,3},{[],[]}}},
@@ -408,7 +408,7 @@ doesnt_exist_test() ->
     Constraints = [{<<"foo">>,[{<<"1.2.3">>, [{<<"bar">>, <<"2.0.0">>, gt}]}]}],
     World = rlx_depsolver:add_packages(rlx_depsolver:new_graph(), Constraints),
     Ret = rlx_depsolver:solve(World, [<<"foo">>]),
-    _ = rlx_depsolver:format_error(Ret, []),
+    _ = rlx_depsolver:format_error(Ret),
     ?assertMatch({error,{unreachable_package,<<"bar">>}}, Ret).
 
 %%
@@ -428,7 +428,7 @@ not_new_enough_test() ->
                    {<<"bar">>, [{<<"2.0.0">>, []}]}],
     World = rlx_depsolver:add_packages(rlx_depsolver:new_graph(), Constraints),
     Ret = rlx_depsolver:solve(World, [<<"foo">>]),
-    _ = rlx_depsolver:format_error(Ret, []),
+    _ = rlx_depsolver:format_error(Ret),
     ?assertMatch({error,
                   [{[{[<<"foo">>],[{<<"foo">>,{{1,2,3},{[],[]}}}]}],
                     [{{<<"foo">>,{{1,2,3},{[],[]}}},
@@ -449,7 +449,7 @@ impossible_dependency_test() ->
                                        [{<<"foo">>, [{<<"1.2.3">>,[{ <<"bar">>, <<"2.0.0">>, gt}]}]},
                                         {<<"bar">>, [{<<"2.0.0">>, [{ <<"foo">>, <<"3.0.0">>, gt}]}]}]),
     Ret = rlx_depsolver:solve(World, [<<"foo">>]),
-    _ = rlx_depsolver:format_error(Ret, []),
+    _ = rlx_depsolver:format_error(Ret),
     ?assertMatch({error,
                   [{[{[<<"foo">>],[{<<"foo">>,{{1,2,3},{[],[]}}}]}],
                     [{{<<"foo">>,{{1,2,3},{[],[]}}},


### PR DESCRIPTION
Ok, so I had moved `format_error` to be `format_error/2` for use in `rebar3` as well. But came to realize that passing the `State` actually makes little sense, since we expect a provider that errors to return `{error, term()}`, so no `State`. Meaning cleanup is already done simply by ignoring any changes a crashed provider does to the state.
