### PR TITLE
Use nodetool to get VM PID

### DIFF
--- a/priv/templates/extended_bin.dtl
+++ b/priv/templates/extended_bin.dtl
@@ -368,7 +368,7 @@ case "$1" in
         exec "$@" -- ${1+$ARGS}
         ;;
     *)
-        echo "Usage: $REL_NAME {start|start_boot <file>|foreground|stop|restart|reboot|ping|console|console_clean|console_boot <file>|attach|remote_console|upgrade|escript}"
+        echo "Usage: $REL_NAME {start|start_boot <file>|foreground|stop|restart|reboot|pid|ping|console|console_clean|console_boot <file>|attach|remote_console|upgrade|escript}"
         exit 1
         ;;
 esac


### PR DESCRIPTION
Rather than use `ps`, `grep` and `awk` to get the `beam.smp` process id,
use the `os:getpid` function.

Also, provide a `pid` command to facilitate retrieving the VM's process
id at a later time. Useful for when running via `monit`, for instance.
