### PR TITLE
Explicitly use 'exit 1' to exit

### DIFF
--- a/priv/templates/extended_bin.dtl
+++ b/priv/templates/extended_bin.dtl
@@ -28,12 +28,12 @@ find_erts_dir() {
 
 # Get node pid
 relx_get_pid() {
-    if pid="$(relx_nodetool rpcterms os getpid)"
+    if output="$(relx_nodetool rpcterms os getpid)"
     then
-        echo "$pid" | sed -e 's/"//g'
+        echo "$output" | sed -e 's/"//g'
         return 0
     else
-        echo '-1'
+        echo "$output"
         return 1
     fi
 }


### PR DESCRIPTION
Fixes #286

Using `exit $?` will exit with 0 status even in error conditions. I believe this is due to the fact that the `if` statement sets `$?` somehow. This could be a bug in the version of `bash` I'm using (as `/bin/sh` on Arch Linux):

```
$ /bin/sh --version
GNU bash, version 4.3.30(1)-release (x86_64-unknown-linux-gnu)
```

Output from testing. The first execution is using a release built with `relx` without these changes - you can see the exit code is 0 even though the ping fails. Then I copy the new `relx`, rebuild, and you can see the correct exit status.

``` sh
$ /tmp/autodeploy/autodeploy_release/bin/autodeploy_release ping; echo $?
Node 'autodeploy@127.0.0.1' not responding to pings.
0

$ cp ~/Projects/src/relx/relx .

$ make clean debug > /dev/null 2>&1

$ /tmp/autodeploy/autodeploy_release/bin/autodeploy_release ping; echo $?
Node 'autodeploy@127.0.0.1' not responding to pings.
1
```
