### PR TITLE
Mainly exclude_apps

### DIFF
--- a/src/rlx_config.erl
+++ b/src/rlx_config.erl
@@ -182,6 +182,8 @@ load_terms({add_providers, Providers0}, {ok, State0}) ->
     end;
 load_terms({skip_apps, SkipApps0}, {ok, State0}) ->
     {ok, rlx_state:skip_apps(State0, SkipApps0)};
+load_terms({exclude_apps, ExcludeApps0}, {ok, State0}) ->
+    {ok, rlx_state:exclude_apps(State0, ExcludeApps0)};
 load_terms({debug_info, DebugInfo}, {ok, State0}) ->
     {ok, rlx_state:debug_info(State0, DebugInfo)};
 load_terms({overrides, Overrides0}, {ok, State0}) ->

--- a/src/rlx_state.erl
+++ b/src/rlx_state.erl
@@ -36,6 +36,8 @@
          overrides/2,
          skip_apps/1,
          skip_apps/2,
+         exclude_apps/1,
+         exclude_apps/2,
          debug_info/1,
          debug_info/2,
          goals/1,
@@ -104,6 +106,7 @@
                   sys_config :: file:filename() | undefined,
                   overrides=[] :: [{AppName::atom(), Directory::file:filename()}],
                   skip_apps=[] :: [AppName::atom()],
+                  exclude_apps=[] :: [AppName::atom()],
                   debug_info=keep :: keep | strip,
                   configured_releases :: releases(),
                   realized_releases :: releases(),
@@ -185,6 +188,15 @@ skip_apps(#state_t{skip_apps=Apps}) ->
 -spec skip_apps(t(), [AppName::atom()]) -> t().
 skip_apps(State, SkipApps) ->
     State#state_t{skip_apps=SkipApps}.
+
+-spec exclude_apps(t()) -> [AppName::atom()].
+exclude_apps(#state_t{exclude_apps=Apps}) ->
+    Apps.
+
+%% @doc the application overrides for the system
+-spec exclude_apps(t(), [AppName::atom()]) -> t().
+exclude_apps(State, SkipApps) ->
+    State#state_t{exclude_apps=SkipApps}.
 
 -spec debug_info(t()) -> keep | strip.
 debug_info(#state_t{debug_info=DebugInfo}) ->

--- a/test/rlx_release_SUITE.erl
+++ b/test/rlx_release_SUITE.erl
@@ -78,13 +78,14 @@ all() ->
 
 make_release(Config) ->
     LibDir1 = proplists:get_value(lib1, Config),
+
     [(fun({Name, Vsn}) ->
               rlx_test_utils:create_app(LibDir1, Name, Vsn, [kernel, stdlib], [])
       end)(App)
-     ||
+    ||
         App <-
             [{rlx_test_utils:create_random_name("lib_app1_"), rlx_test_utils:create_random_vsn()}
-             || _ <- lists:seq(1, 100)]],
+            || _ <- lists:seq(1, 100)]],
 
     rlx_test_utils:create_app(LibDir1, "goal_app_1", "0.0.1", [stdlib,kernel,non_goal_1], []),
     rlx_test_utils:create_app(LibDir1, "lib_dep_1", "0.0.1", [stdlib,kernel], []),
@@ -116,13 +117,6 @@ make_release(Config) ->
 
 make_extend_release(Config) ->
     LibDir1 = proplists:get_value(lib1, Config),
-    [(fun({Name, Vsn}) ->
-              rlx_test_utils:create_app(LibDir1, Name, Vsn, [kernel, stdlib], [])
-      end)(App)
-     ||
-        App <-
-            [{rlx_test_utils:create_random_name("lib_app1_"), rlx_test_utils:create_random_vsn()}
-             || _ <- lists:seq(1, 100)]],
 
     rlx_test_utils:create_app(LibDir1, "goal_app_1", "0.0.1", [stdlib,kernel,non_goal_1], []),
     rlx_test_utils:create_app(LibDir1, "lib_dep_1", "0.0.1", [stdlib,kernel], []),
@@ -158,13 +152,6 @@ make_extend_release(Config) ->
 
 make_invalid_config_release(Config) ->
     LibDir1 = proplists:get_value(lib1, Config),
-    [(fun({Name, Vsn}) ->
-              rlx_test_utils:create_app(LibDir1, Name, Vsn, [kernel, stdlib], [])
-      end)(App)
-     ||
-        App <-
-            [{rlx_test_utils:create_random_name("lib_app1_"), rlx_test_utils:create_random_vsn()}
-             || _ <- lists:seq(1, 100)]],
 
     rlx_test_utils:create_app(LibDir1, "goal_app_1", "0.0.1", [stdlib,kernel,non_goal_1], []),
     rlx_test_utils:create_app(LibDir1, "lib_dep_1", "0.0.1", [stdlib,kernel], []),
@@ -185,13 +172,6 @@ make_invalid_config_release(Config) ->
 
 make_scriptless_release(Config) ->
     LibDir1 = proplists:get_value(lib1, Config),
-    [(fun({Name, Vsn}) ->
-              rlx_test_utils:create_app(LibDir1, Name, Vsn, [kernel, stdlib], [])
-      end)(App)
-     ||
-        App <-
-            [{rlx_test_utils:create_random_name("lib_app1_"), rlx_test_utils:create_random_vsn()}
-             || _ <- lists:seq(1, 100)]],
 
     rlx_test_utils:create_app(LibDir1, "goal_app_1", "0.0.1", [stdlib,kernel,non_goal_1], []),
     rlx_test_utils:create_app(LibDir1, "lib_dep_1", "0.0.1", [stdlib,kernel], []),
@@ -227,13 +207,7 @@ make_overridden_release(Config) ->
     DataDir = proplists:get_value(data_dir, Config),
     OverrideDir1 = filename:join([DataDir, rlx_test_utils:create_random_name("override_dir_")]),
     LibDir1 = proplists:get_value(lib1, Config),
-    [(fun({Name, Vsn}) ->
-              rlx_test_utils:create_app(LibDir1, Name, Vsn, [kernel, stdlib], [])
-      end)(App)
-     ||
-        App <-
-            [{rlx_test_utils:create_random_name("lib_app1_"), rlx_test_utils:create_random_vsn()}
-             || _ <- lists:seq(1, 100)]],
+
     OverrideApp = rlx_test_utils:create_random_name("override_app"),
     OverrideVsn = rlx_test_utils:create_random_vsn(),
     OverrideAppDir = filename:join(OverrideDir1, OverrideApp ++ "-" ++ OverrideVsn),
@@ -275,13 +249,6 @@ make_overridden_release(Config) ->
 
 make_skip_app_release(Config) ->
     LibDir1 = proplists:get_value(lib1, Config),
-    [(fun({Name, Vsn}) ->
-              rlx_test_utils:create_app(LibDir1, Name, Vsn, [kernel, stdlib], [])
-      end)(App)
-     ||
-        App <-
-            [{rlx_test_utils:create_random_name("lib_app1_"), rlx_test_utils:create_random_vsn()}
-             || _ <- lists:seq(1, 100)]],
 
     rlx_test_utils:create_app(LibDir1, "goal_app_1", "0.0.1", [stdlib,kernel,non_goal_1], []),
     rlx_test_utils:create_app(LibDir1, "lib_dep_1", "0.0.1", [stdlib,kernel], []),
@@ -341,13 +308,7 @@ make_auto_skip_empty_app_release(Config) ->
     DataDir = proplists:get_value(data_dir, Config),
     EmptyAppDir1 = filename:join([DataDir, rlx_test_utils:create_random_name("skip_app_dir_")]),
     LibDir1 = proplists:get_value(lib1, Config),
-    [(fun({Name, Vsn}) ->
-              rlx_test_utils:create_app(LibDir1, Name, Vsn, [kernel, stdlib], [])
-      end)(App)
-     ||
-        App <-
-            [{rlx_test_utils:create_random_name("lib_app1_"), rlx_test_utils:create_random_vsn()}
-             || _ <- lists:seq(1, 100)]],
+
     EmptyAppApp = rlx_test_utils:create_random_name("empty_app_app"),
     EmptyAppVsn = rlx_test_utils:create_random_vsn(),
     EmptyAppAppName = erlang:list_to_atom(EmptyAppApp),
@@ -384,13 +345,6 @@ make_auto_skip_empty_app_release(Config) ->
 
 make_app_type_none_release(Config) ->
     LibDir1 = proplists:get_value(lib1, Config),
-    [(fun({Name, Vsn}) ->
-              rlx_test_utils:create_app(LibDir1, Name, Vsn, [kernel, stdlib], [])
-      end)(App)
-     ||
-        App <-
-            [{rlx_test_utils:create_random_name("lib_app1_"), rlx_test_utils:create_random_vsn()}
-             || _ <- lists:seq(1, 100)]],
 
     rlx_test_utils:create_app(LibDir1, "goal_app_1", "0.0.1", [stdlib,kernel,non_goal_1], []),
     rlx_test_utils:create_app(LibDir1, "lib_dep_1", "0.0.1", [stdlib,kernel], []),
@@ -423,13 +377,6 @@ make_implicit_config_release(Config) ->
     LibDir1 = proplists:get_value(lib1, Config),
     FooRoot = filename:join([LibDir1, "foodir1", "foodir2"]),
     filelib:ensure_dir(filename:join([FooRoot, "tmp"])),
-    [(fun({Name, Vsn}) ->
-              rlx_test_utils:create_app(LibDir1, Name, Vsn, [kernel, stdlib], [])
-      end)(App)
-     ||
-        App <-
-            [{rlx_test_utils:create_random_name("lib_app1_"), rlx_test_utils:create_random_vsn()}
-             || _ <- lists:seq(1, 100)]],
 
     rlx_test_utils:create_app(LibDir1, "goal_app_1", "0.0.1", [stdlib,kernel,non_goal_1], []),
     rlx_test_utils:create_app(LibDir1, "lib_dep_1", "0.0.1", [stdlib,kernel], []),
@@ -463,13 +410,7 @@ make_rerun_overridden_release(Config) ->
     DataDir = proplists:get_value(data_dir, Config),
     OverrideDir1 = filename:join([DataDir, rlx_test_utils:create_random_name("override_dir_")]),
     LibDir1 = proplists:get_value(lib1, Config),
-    [(fun({Name, Vsn}) ->
-              rlx_test_utils:create_app(LibDir1, Name, Vsn, [kernel, stdlib], [])
-      end)(App)
-     ||
-        App <-
-            [{rlx_test_utils:create_random_name("lib_app1_"), rlx_test_utils:create_random_vsn()}
-             || _ <- lists:seq(1, 100)]],
+
     OverrideApp = rlx_test_utils:create_random_name("override_app"),
     OverrideVsn = rlx_test_utils:create_random_vsn(),
     OverrideAppDir = filename:join(OverrideDir1, OverrideApp ++ "-"
@@ -520,13 +461,6 @@ make_rerun_overridden_release(Config) ->
 
 overlay_release(Config) ->
     LibDir1 = proplists:get_value(lib1, Config),
-    [(fun({Name, Vsn}) ->
-              rlx_test_utils:create_app(LibDir1, Name, Vsn, [kernel, stdlib], [])
-      end)(App)
-     ||
-        App <-
-            [{rlx_test_utils:create_random_name("lib_app1_"), rlx_test_utils:create_random_vsn()}
-             || _ <- lists:seq(1, 100)]],
 
     rlx_test_utils:create_app(LibDir1, "goal_app_1", "0.0.1", [stdlib,kernel,non_goal_1], []),
     rlx_test_utils:create_app(LibDir1, "lib_dep_1", "0.0.1", [stdlib,kernel], []),
@@ -675,13 +609,6 @@ overlay_release(Config) ->
 
 make_goalless_release(Config) ->
     LibDir1 = proplists:get_value(lib1, Config),
-    [(fun({Name, Vsn}) ->
-              rlx_test_utils:create_app(LibDir1, Name, Vsn, [kernel, stdlib], [])
-      end)(App)
-     ||
-        App <-
-            [{rlx_test_utils:create_random_name("lib_app1_"), rlx_test_utils:create_random_vsn()}
-             || _ <- lists:seq(1, 100)]],
 
     rlx_test_utils:create_app(LibDir1, "goal_app_1", "0.0.1", [stdlib,kernel,non_goal_1], []),
     rlx_test_utils:create_app(LibDir1, "lib_dep_1", "0.0.1", [], []),
@@ -701,13 +628,6 @@ make_goalless_release(Config) ->
 
 make_depfree_release(Config) ->
     LibDir1 = proplists:get_value(lib1, Config),
-    [(fun({Name, Vsn}) ->
-              rlx_test_utils:create_app(LibDir1, Name, Vsn, [kernel, stdlib], [])
-      end)(App)
-     ||
-        App <-
-            [{rlx_test_utils:create_random_name("lib_app1_"), rlx_test_utils:create_random_vsn()}
-             || _ <- lists:seq(1, 100)]],
 
     rlx_test_utils:create_app(LibDir1, "goal_app_1", "0.0.1", [kernel,stdlib], []),
     rlx_test_utils:create_app(LibDir1, "lib_dep_1", "0.0.1", [kernel,stdlib], []),
@@ -730,13 +650,6 @@ make_depfree_release(Config) ->
 
 make_relup_release(Config) ->
     LibDir1 = proplists:get_value(lib1, Config),
-    [(fun({Name, Vsn}) ->
-              rlx_test_utils:create_app(LibDir1, Name, Vsn, [kernel, stdlib], [])
-      end)(App)
-     ||
-        App <-
-            [{rlx_test_utils:create_random_name("lib_app1_"), rlx_test_utils:create_random_vsn()}
-             || _ <- lists:seq(1, 100)]],
 
     rlx_test_utils:create_app(LibDir1, "goal_app_1", "0.0.1", [stdlib,kernel,non_goal_1], []),
     rlx_test_utils:create_app(LibDir1, "goal_app_1", "0.0.2", [stdlib,kernel,non_goal_1], []),
@@ -817,13 +730,6 @@ make_relup_release(Config) ->
 
 make_relup_release2(Config) ->
     LibDir1 = proplists:get_value(lib1, Config),
-    [(fun({Name, Vsn}) ->
-              rlx_test_utils:create_app(LibDir1, Name, Vsn, [kernel, stdlib], [])
-      end)(App)
-     ||
-        App <-
-            [{rlx_test_utils:create_random_name("lib_app1_"), rlx_test_utils:create_random_vsn()}
-             || _ <- lists:seq(1, 100)]],
 
     rlx_test_utils:create_app(LibDir1, "goal_app_1", "0.0.1", [stdlib,kernel,non_goal_1], []),
     rlx_test_utils:create_app(LibDir1, "goal_app_1", "0.0.2", [stdlib,kernel,non_goal_1], []),
@@ -921,13 +827,6 @@ make_one_app_top_level_release(Config) ->
 
 make_dev_mode_release(Config) ->
     LibDir1 = proplists:get_value(lib1, Config),
-    [(fun({Name, Vsn}) ->
-              rlx_test_utils:create_app(LibDir1, Name, Vsn, [kernel, stdlib], [])
-      end)(App)
-     ||
-        App <-
-            [{rlx_test_utils:create_random_name("lib_app1_"), rlx_test_utils:create_random_vsn()}
-             || _ <- lists:seq(1, 100)]],
 
     rlx_test_utils:create_app(LibDir1, "goal_app_1", "0.0.1", [stdlib,kernel,non_goal_1], []),
     rlx_test_utils:create_app(LibDir1, "lib_dep_1", "0.0.1", [stdlib,kernel], []),
@@ -969,13 +868,6 @@ make_config_script_release(Config) ->
     LibDir1 = proplists:get_value(lib1, Config),
     FooRoot = filename:join([LibDir1, "foodir1", "foodir2"]),
     filelib:ensure_dir(filename:join([FooRoot, "tmp"])),
-    [(fun({Name, Vsn}) ->
-              rlx_test_utils:create_app(LibDir1, Name, Vsn, [kernel, stdlib], [])
-      end)(App)
-     ||
-        App <-
-            [{rlx_test_utils:create_random_name("lib_app1_"), rlx_test_utils:create_random_vsn()}
-             || _ <- lists:seq(1, 100)]],
 
     rlx_test_utils:create_app(LibDir1, "goal_app_1", "0.0.1", [stdlib,kernel,non_goal_1], []),
     rlx_test_utils:create_app(LibDir1, "lib_dep_1", "0.0.1", [stdlib,kernel], []),

--- a/test/rlx_release_SUITE.erl
+++ b/test/rlx_release_SUITE.erl
@@ -29,6 +29,7 @@
          make_scriptless_release/1,
          make_overridden_release/1,
          make_skip_app_release/1,
+         make_exclude_app_release/1,
          make_auto_skip_empty_app_release/1,
          make_app_type_none_release/1,
          make_rerun_overridden_release/1,
@@ -68,7 +69,7 @@ init_per_testcase(_, Config) ->
 all() ->
     [make_release, make_extend_release, make_scriptless_release,
      make_overridden_release, make_auto_skip_empty_app_release,
-     make_skip_app_release, make_app_type_none_release,
+     make_skip_app_release, make_exclude_app_release, make_app_type_none_release,
      make_implicit_config_release, make_rerun_overridden_release,
      overlay_release, make_goalless_release, make_depfree_release,
      make_invalid_config_release, make_relup_release, make_relup_release2,
@@ -308,6 +309,33 @@ make_skip_app_release(Config) ->
     ?assert(lists:member({goal_app_1, "0.0.1"}, AppSpecs)),
     ?assertNot(lists:member({goal_app_2, "0.0.1"}, AppSpecs)),
     ?assert(lists:member({lib_dep_1, "0.0.1", load}, AppSpecs)).
+
+%% Test to ensure that an excluded app and its deps are not included in a release
+make_exclude_app_release(Config) ->
+    LibDir1 = proplists:get_value(lib1, Config),
+
+    rlx_test_utils:create_app(LibDir1, "goal_app_1", "0.0.1", [stdlib,kernel, non_goal_1], []),
+    rlx_test_utils:create_app(LibDir1, "non_goal_1", "0.0.1", [stdlib,kernel, non_goal_2], []),
+    rlx_test_utils:create_app(LibDir1, "non_goal_2", "0.0.1", [stdlib,kernel], []),
+
+    ConfigFile = filename:join([LibDir1, "relx.config"]),
+    rlx_test_utils:write_config(ConfigFile,
+                 [{release, {foo, "0.0.1"},
+                   [goal_app_1]},
+                  {exclude_apps, [non_goal_1]}]),
+    OutputDir = filename:join([proplists:get_value(data_dir, Config),
+                               rlx_test_utils:create_random_name("relx-output")]),
+    {ok, Cwd} = file:get_cwd(),
+    {ok, State} = relx:do(Cwd, undefined, undefined, [], [LibDir1], 3,
+                          OutputDir, [],
+                          ConfigFile),
+    [{{foo, "0.0.1"}, Release}] = ec_dictionary:to_list(rlx_state:realized_releases(State)),
+    AppSpecs = rlx_release:applications(Release),
+    ?assert(lists:keymember(stdlib, 1, AppSpecs)),
+    ?assert(lists:keymember(kernel, 1, AppSpecs)),
+    ?assertNot(lists:member({non_goal_1, "0.0.1"}, AppSpecs)),
+    ?assertNot(lists:member({non_goal_2, "0.0.1"}, AppSpecs)),
+    ?assert(lists:member({goal_app_1, "0.0.1"}, AppSpecs)).
 
 make_auto_skip_empty_app_release(Config) ->
     DataDir = proplists:get_value(data_dir, Config),


### PR DESCRIPTION
I've added support for `exclude_apps` used as:

```erlang
{exclude_apps, [ssl]}.
```

This is a fix for https://github.com/erlware/relx/issues/301

Not to be confused with `skip_apps` which is only useful if you have an app in the path that you don't want to be processed -- but if it was still a dep of something you expect it to error that it is not found.