### PR TITLE
prevent files in the bin directory from being duplicated in the .tar

### DIFF
--- a/src/rlx_prv_archive.erl
+++ b/src/rlx_prv_archive.erl
@@ -156,6 +156,8 @@ to({mkdir, To}) ->
 to({template, _, To}) ->
     To.
 
+filter({_, _, "bin/"++_}) ->
+    false;
 filter({copy, _, _}) ->
     true;
 filter({mkdir, _}) ->


### PR DESCRIPTION
update_tar/6 first adds the bin directory, then adds overlay files.  If an
overlay copies to bin, it will be added again.