### PR TITLE
don't return value as string if not a printable string

### DIFF
--- a/src/rlx_util.erl
+++ b/src/rlx_util.erl
@@ -133,7 +133,12 @@ is_error(_) ->
 optional_to_string(undefined) ->
     "";
 optional_to_string(Value) when is_list(Value) ->
-    Value.
+    case io_lib:printable_list(Value) of
+        true ->
+            Value;
+        false ->
+            ""
+    end.
 
 %% @doc expand wildcards and names in the given paths
 -spec wildcard_paths([file:filename_all()]) -> [string()].


### PR DESCRIPTION
Fixes using `--verbose 3` when calling relx through the api and passing a proplist for config instead of a file path. This makes sure it doesn't try printing it as a file path unless it is a printable string.