### PR TITLE
no longer run release before tar or relup, the user must call it

### DIFF
--- a/src/relx.app.src
+++ b/src/relx.app.src
@@ -1,6 +1,6 @@
 {application,relx,
              [{description,"Release assembler for Erlang/OTP Releases"},
-              {vsn,"2.1.1"},
+              {vsn,"3.0.0"},
               {modules,[]},
               {registered,[]},
               {applications,[kernel,stdlib,getopt,erlware_commons,bbmustache,

--- a/src/rlx_prv_archive.erl
+++ b/src/rlx_prv_archive.erl
@@ -31,7 +31,7 @@
 -include("relx.hrl").
 
 -define(PROVIDER, tar).
--define(DEPS, [release]).
+-define(DEPS, [resolve_release]).
 
 %%============================================================================
 %% API

--- a/src/rlx_prv_release.erl
+++ b/src/rlx_prv_release.erl
@@ -29,7 +29,7 @@
 -include("relx.hrl").
 
 -define(PROVIDER, resolve_release).
--define(DEPS, [app_discover]).
+-define(DEPS, [rel_discover]).
 
 %%============================================================================
 %% API

--- a/src/rlx_prv_relup.erl
+++ b/src/rlx_prv_relup.erl
@@ -31,7 +31,7 @@
 -include("relx.hrl").
 
 -define(PROVIDER, relup).
--define(DEPS, [rel_discover, release]).
+-define(DEPS, [resolve_release]).
 
 %%============================================================================
 %% API

--- a/test/rlx_discover_SUITE.erl
+++ b/test/rlx_discover_SUITE.erl
@@ -223,11 +223,11 @@ get_bad_app_metadata(Name, Vsn) ->
 
 
 create_random_name(Name) ->
-    random:seed(erlang:now()),
+    random:seed(os:timestamp()),
     Name ++ erlang:integer_to_list(random:uniform(1000000)).
 
 create_random_vsn() ->
-    random:seed(erlang:now()),
+    random:seed(os:timestamp()),
     lists:flatten([erlang:integer_to_list(random:uniform(100)),
                    ".", erlang:integer_to_list(random:uniform(100)),
                    ".", erlang:integer_to_list(random:uniform(100))]).

--- a/test/rlx_test_utils.erl
+++ b/test/rlx_test_utils.erl
@@ -45,11 +45,11 @@ get_app_metadata(Name, Vsn, Deps, LibDeps) ->
       {applications, Deps}]}.
 
 create_random_name(Name) ->
-    random:seed(erlang:now()),
+    random:seed(os:timestamp()),
     Name ++ erlang:integer_to_list(random:uniform(1000000)).
 
 create_random_vsn() ->
-    random:seed(erlang:now()),
+    random:seed(os:timestamp()),
     lists:flatten([erlang:integer_to_list(random:uniform(100)),
                    ".", erlang:integer_to_list(random:uniform(100)),
                    ".", erlang:integer_to_list(random:uniform(100))]).


### PR DESCRIPTION
This change means that calling `relx tar` will no longer actually be `relx release tar`. This is an important change for fixing https://github.com/rebar/rebar3/issues/518 in rebar3 and isn't a feature people used from what I understand (and I checked with Loic about erlang.mk).