### PR TITLE
Remove bashisms from run scripts

### DIFF
--- a/priv/templates/bin
+++ b/priv/templates/bin
@@ -11,30 +11,30 @@ REL_DIR="$RELEASE_ROOT_DIR/releases/$REL_VSN"
 ERL_OPTS="{{ erl_opts }}"
 
 find_erts_dir() {
-    l_erts_dir="$RELEASE_ROOT_DIR/erts-$ERTS_VSN"
-    if [ -d "$l_erts_dir" ]; then
-        ERTS_DIR="$l_erts_dir";
+    __erts_dir="$RELEASE_ROOT_DIR/erts-$ERTS_VSN"
+    if [ -d "$__erts_dir" ]; then
+        ERTS_DIR="$__erts_dir";
         ROOTDIR="$RELEASE_ROOT_DIR"
     else
-        l_erl="$(which erl)"
+        __erl="$(which erl)"
         code="io:format(\"~s\", [code:root_dir()]), halt()."
-        l_erl_root="$("$l_erl" -noshell -eval "$code")"
-        ERTS_DIR="$l_erl_root/erts-$ERTS_VSN"
-        ROOTDIR="$l_erl_root"
+        __erl_root="$("$__erl" -noshell -eval "$code")"
+        ERTS_DIR="$__erl_root/erts-$ERTS_VSN"
+        ROOTDIR="$__erl_root"
     fi
 }
 
 find_sys_config() {
-    l_possible_sys="$REL_DIR/sys.config"
-    if [ -f "$l_possible_sys" ]; then
-        SYS_CONFIG="$l_possible_sys"
+    __possible_sys="$REL_DIR/sys.config"
+    if [ -f "$__possible_sys" ]; then
+        SYS_CONFIG="$__possible_sys"
     fi
 }
 
 find_vm_args() {
-    l_possible_vm_args="$REL_DIR/vm.args"
-    if [ -f "$l_possible_vm_args" ]; then
-        VM_ARGS="$l_possible_vm_args"
+    __possible_vm_args="$REL_DIR/vm.args"
+    if [ -f "$__possible_vm_args" ]; then
+        VM_ARGS="$__possible_vm_args"
     fi
 }
 

--- a/priv/templates/bin
+++ b/priv/templates/bin
@@ -11,30 +11,30 @@ REL_DIR="$RELEASE_ROOT_DIR/releases/$REL_VSN"
 ERL_OPTS="{{ erl_opts }}"
 
 find_erts_dir() {
-    local erts_dir="$RELEASE_ROOT_DIR/erts-$ERTS_VSN"
-    if [ -d "$erts_dir" ]; then
-        ERTS_DIR="$erts_dir";
+    l_erts_dir="$RELEASE_ROOT_DIR/erts-$ERTS_VSN"
+    if [ -d "$l_erts_dir" ]; then
+        ERTS_DIR="$l_erts_dir";
         ROOTDIR="$RELEASE_ROOT_DIR"
     else
-        local erl="$(which erl)"
+        l_erl="$(which erl)"
         code="io:format(\"~s\", [code:root_dir()]), halt()."
-        local erl_root="$("$erl" -noshell -eval "$code")"
-        ERTS_DIR="$erl_root/erts-$ERTS_VSN"
-        ROOTDIR="$erl_root"
+        l_erl_root="$("$l_erl" -noshell -eval "$code")"
+        ERTS_DIR="$l_erl_root/erts-$ERTS_VSN"
+        ROOTDIR="$l_erl_root"
     fi
 }
 
 find_sys_config() {
-    local possible_sys="$REL_DIR/sys.config"
-    if [ -f "$possible_sys" ]; then
-        SYS_CONFIG="$possible_sys"
+    l_possible_sys="$REL_DIR/sys.config"
+    if [ -f "$l_possible_sys" ]; then
+        SYS_CONFIG="$l_possible_sys"
     fi
 }
 
 find_vm_args() {
-    local possible_vm_args="$REL_DIR/vm.args"
-    if [ -f "$possible_vm_args" ]; then
-        VM_ARGS="$possible_vm_args"
+    l_possible_vm_args="$REL_DIR/vm.args"
+    if [ -f "$l_possible_vm_args" ]; then
+        VM_ARGS="$l_possible_vm_args"
     fi
 }
 

--- a/priv/templates/extended_bin
+++ b/priv/templates/extended_bin
@@ -13,16 +13,16 @@ ERL_OPTS="{{ erl_opts }}"
 RUNNER_LOG_DIR="${RUNNER_LOG_DIR:-$RELEASE_ROOT_DIR/log}"
 
 find_erts_dir() {
-    l_erts_dir="$RELEASE_ROOT_DIR/erts-$ERTS_VSN"
-    if [ -d "$l_erts_dir" ]; then
-        ERTS_DIR="$l_erts_dir";
+    __erts_dir="$RELEASE_ROOT_DIR/erts-$ERTS_VSN"
+    if [ -d "$__erts_dir" ]; then
+        ERTS_DIR="$__erts_dir";
         ROOTDIR="$RELEASE_ROOT_DIR"
     else
-        l_erl="$(which erl)"
+        __erl="$(which erl)"
         code="io:format(\"~s\", [code:root_dir()]), halt()."
-        l_erl_root="$("$l_erl" -noshell -eval "$code")"
-        ERTS_DIR="$l_erl_root/erts-$ERTS_VSN"
-        ROOTDIR="$l_erl_root"
+        __erl_root="$("$__erl" -noshell -eval "$code")"
+        ERTS_DIR="$__erl_root/erts-$ERTS_VSN"
+        ROOTDIR="$__erl_root"
     fi
 }
 

--- a/priv/templates/extended_bin
+++ b/priv/templates/extended_bin
@@ -13,16 +13,16 @@ ERL_OPTS="{{ erl_opts }}"
 RUNNER_LOG_DIR="${RUNNER_LOG_DIR:-$RELEASE_ROOT_DIR/log}"
 
 find_erts_dir() {
-    local erts_dir="$RELEASE_ROOT_DIR/erts-$ERTS_VSN"
-    if [ -d "$erts_dir" ]; then
-        ERTS_DIR="$erts_dir";
+    l_erts_dir="$RELEASE_ROOT_DIR/erts-$ERTS_VSN"
+    if [ -d "$l_erts_dir" ]; then
+        ERTS_DIR="$l_erts_dir";
         ROOTDIR="$RELEASE_ROOT_DIR"
     else
-        local erl="$(which erl)"
+        l_erl="$(which erl)"
         code="io:format(\"~s\", [code:root_dir()]), halt()."
-        local erl_root="$("$erl" -noshell -eval "$code")"
-        ERTS_DIR="$erl_root/erts-$ERTS_VSN"
-        ROOTDIR="$erl_root"
+        l_erl_root="$("$l_erl" -noshell -eval "$code")"
+        ERTS_DIR="$l_erl_root/erts-$ERTS_VSN"
+        ROOTDIR="$l_erl_root"
     fi
 }
 
@@ -216,7 +216,7 @@ case "$1" in
         if ! relx_nodetool "stop"; then
             exit 1
         fi
-        while $(kill -0 "$PID" 2>/dev/null);
+        while $(kill -s 0 "$PID" 2>/dev/null);
         do
             sleep 1
         done


### PR DESCRIPTION
This commit removes the bashisms in `bin` and `extended_bin`.
Both of these scripts used `local` variables which are a bash
addition and aren't supported on Solaris/SmartOS `/bin/sh`. To keep
the local intention of the variables, they were renamed from `$var` to
`$l_var`.

In addition, `extended_bin` used `kill -SIGNAL $PID` which is also
not in Solaris `kill`. It was replaced with the standard `kill -s SIGNAL $PID`

Fixes: #351 