### PR TITLE
make config names unique

### DIFF
--- a/priv/templates/extended_bin
+++ b/priv/templates/extended_bin
@@ -97,8 +97,10 @@ if [ -z "$VMARGS_PATH" ]; then
 fi
 
 if [ $RELX_REPLACE_OS_VARS ]; then
-    awk '{while(match($0,"[$]{[^}]*}")) {var=substr($0,RSTART+2,RLENGTH -3);gsub("[$]{"var"}",ENVIRON[var])}}1' < $VMARGS_PATH > $VMARGS_PATH.2.config
-    VMARGS_PATH=$VMARGS_PATH.2.config
+    rm -f $REL_DIR/*@uniq*config
+    UNIQ=`od -N 4 -t uL -An /dev/urandom | tr -d " "`
+    awk '{while(match($0,"[$]{[^}]*}")) {var=substr($0,RSTART+2,RLENGTH -3);gsub("[$]{"var"}",ENVIRON[var])}}1' < $VMARGS_PATH > $VMARGS_PATH.@uniq$UNIQ.config
+    VMARGS_PATH=$VMARGS_PATH.@uniq$UNIQ.config
 fi
 
 # Make sure log directory exists
@@ -113,8 +115,8 @@ if [ -z "$RELX_CONFIG_PATH" ]; then
 fi
 
 if [ $RELX_REPLACE_OS_VARS ]; then
-    awk '{while(match($0,"[$]{[^}]*}")) {var=substr($0,RSTART+2,RLENGTH -3);gsub("[$]{"var"}",ENVIRON[var])}}1' < $RELX_CONFIG_PATH > $RELX_CONFIG_PATH.2.config
-    RELX_CONFIG_PATH=$RELX_CONFIG_PATH.2.config
+    awk '{while(match($0,"[$]{[^}]*}")) {var=substr($0,RSTART+2,RLENGTH -3);gsub("[$]{"var"}",ENVIRON[var])}}1' < $RELX_CONFIG_PATH > $RELX_CONFIG_PATH.@uniq$UNIQ.config
+    RELX_CONFIG_PATH=$RELX_CONFIG_PATH.@uniq$UNIQ.config
 fi
 
 # Extract the target node name from node.args


### PR DESCRIPTION
when using RELX_REPLACE_OS_VARS to start multiple release nodes, there
is a startup race since all of the releases are attempting to use the
same release file ($name.2.config).  This code generates a random
identifier so that each release start uses a separate file, then cleans
up after itself so it doesn't leak config files.

I'm not super pleased by the rm at line 100.  I think that it's safe enough, but ugly and potentially fragile.  Any other suggestions are welcomed.  I did it that way because it's rather hard to clean up since there are so many paths, and several of them end in exec.  I wonder if this entire code path shouldn't additionally be walled off behind a `MULTINODE_TESTING` flag, since this isn't ideal behavior in production.