### PR TITLE
Remove unnecessary `compile_source` option from `escript:extract/2`.

### DIFF
--- a/src/rlx_util.erl
+++ b/src/rlx_util.erl
@@ -195,7 +195,7 @@ escript_files() ->
     end.
 
 escript_foldl(Fun, Acc, File) ->
-    case escript:extract(File, [compile_source]) of
+    case escript:extract(File, []) of
         {ok, [_Shebang, _Comment, _EmuArgs, Body]} ->
             case Body of
                 {source, BeamCode} ->


### PR DESCRIPTION
- This was printing error output if the caller was not an escript,
  regardless of error handling strategy.
- The option is not actually required for extracting a valid escript.