### PR TITLE
version bump: 3.1.0

### DIFF
--- a/src/relx.app.src
+++ b/src/relx.app.src
@@ -1,6 +1,6 @@
 {application,relx,
              [{description,"Release assembler for Erlang/OTP Releases"},
-              {vsn,"3.0.0"},
+              {vsn,"3.1.0"},
               {modules,[]},
               {registered,[]},
               {applications,[kernel,stdlib,getopt,erlware_commons,bbmustache,


### PR DESCRIPTION
This bump is for including the last commit, https://github.com/erlware/relx/commit/27f2aef243da1b3623ffeda497a4efa6a19828c8, in a published release on hex, that is an important fix for using relx in exrm and mix.