### PR TITLE
Now you can specify {semver, "version"}

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,6 +1,6 @@
 %% -*- mode: Erlang; fill-column: 80; comment-column: 75; -*-
 %% Dependencies ================================================================
-{deps, [{erlware_commons, "0.13.0"},
+{deps, [{erlware_commons, "0.14.0"},
         {providers, "1.4.1"},
         {getopt, "0.8.2"},
         {bbmustache, "1.0.3"}

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,4 +1,4 @@
 [{<<"bbmustache">>,{pkg,<<"bbmustache">>,<<"1.0.3">>},0},
  {<<"providers">>,{pkg,<<"providers">>,<<"1.4.1">>},0},
- {<<"erlware_commons">>,{pkg,<<"erlware_commons">>,<<"0.13.0">>},0},
+ {<<"erlware_commons">>,{pkg,<<"erlware_commons">>,<<"0.14.0">>},0},
  {<<"getopt">>,{pkg,<<"getopt">>,<<"0.8.2">>},0}].

--- a/src/rlx_config.erl
+++ b/src/rlx_config.erl
@@ -295,7 +295,9 @@ merge_configs([{Key, Value} | CliTerms], ConfigTerms) ->
     end.
 
 parse_vsn(Vsn) when Vsn =:= semver ; Vsn =:= "semver" ->
-    {ok, V} = ec_git_vsn:vsn([]),
+    parse_vsn({semver, "v"});
+parse_vsn({semver, Prefix}) ->
+    {ok, V} = ec_git_vsn:vsn({Prefix}),
     V;
 parse_vsn(Vsn) ->
     Vsn.


### PR DESCRIPTION
where "version" is the prefix you use for tagging versions in git