### PR TITLE
Added {cmd, Cmd} to version attribute.

### DIFF
--- a/src/rlx_config.erl
+++ b/src/rlx_config.erl
@@ -299,5 +299,8 @@ parse_vsn(Vsn) when Vsn =:= semver ; Vsn =:= "semver" ->
 parse_vsn({semver, Prefix}) ->
     {ok, V} = ec_git_vsn:vsn({Prefix}),
     V;
+parse_vsn({cmd, Command}) ->
+    V = os:cmd(Command),
+    V;
 parse_vsn(Vsn) ->
     Vsn.


### PR DESCRIPTION
Whatever CMD returns will be the version number

We'll want to include the other PR from erlware commons in this rebar config, but we'll need to wait until it's tagged.