### PR TITLE
Add include dirs to tar file

### DIFF
--- a/src/rlx_prv_archive.erl
+++ b/src/rlx_prv_archive.erl
@@ -67,6 +67,7 @@ make_tar(State, Release, OutputDir) ->
     Vsn = rlx_release:vsn(Release),
     ErtsVersion = rlx_release:erts(Release),
     Opts = [{path, [filename:join([OutputDir, "lib", "*", "ebin"])]},
+            {dirs, [include]},
             {outdir, OutputDir} |
             case rlx_state:get(State, include_erts, true) of
                 true ->


### PR DESCRIPTION
This PR adds `include` directories from libs to the tar.gz. Many libraries have includes and they are not being added.
This fixes issue https://github.com/rebar/rebar3/issues/630