### PR TITLE
Possibility for plugins to create custom actions/tasks

### DIFF
--- a/src/rlx_state.erl
+++ b/src/rlx_state.erl
@@ -125,7 +125,7 @@
                                              rlx_release:t()).
 -type cmd_args() :: proplists:proplist().
 -type caller() :: command_line | api.
--type action() :: release | relup | tar.
+-type action() :: atom().
 
 -opaque t() :: #state_t{}.
 


### PR DESCRIPTION
Before this commit provider wasn't able to create custom action. This feature is
critical when you want to create custom plugins, such as rpm or deb generation
plugin and load them using `{add_provider, [...]}` in the relx.config file.

Now when we're parsing actions/targets in `rlx_cmd_args` we didn't check them,
just converting to atoms. In order to display error message about wrong action,
we have to add another check in `relx:run_providers` function.

Thanks!