### PR TITLE
'od' only needs to read 4 bytes of random data

### DIFF
--- a/priv/templates/extended_bin
+++ b/priv/templates/extended_bin
@@ -60,7 +60,7 @@ relx_rem_sh() {
 
 # Generate a random id
 relx_gen_id() {
-    od -X /dev/urandom | head -n1 | awk '{print $2}'
+    od -X -N 4 /dev/urandom | head -n1 | awk '{print $2}'
 }
 
 # Control a node


### PR DESCRIPTION
'-N 4' option looks portable across all major flavors of *BSD, Linux, OSX
Adding this option prevents a strange case where 'od' can go to
100% CPU in restart scenarios.

Generally, it just makes ID generation more efficient and predictable since it will never read more than 4 bytes of random data.