### PR TITLE
remove relx from list of incl_apps, it is inlcuded by default

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -9,7 +9,7 @@
 {escript_incl_extra, [{"priv/templates/*", "."}]}.
 {escript_emu_args, "%%! +sbtu +A0 -noinput\n"}.
 {escript_incl_apps,
- [getopt, erlware_commons, bbmustache, providers, relx]}.
+ [getopt, erlware_commons, bbmustache, providers]}.
 
 %% Compiler Options ============================================================
 {erl_opts,


### PR DESCRIPTION
Fixes https://github.com/erlware/relx/issues/385