### PR TITLE
Startup script improvements

### DIFF
--- a/priv/templates/bin
+++ b/priv/templates/bin
@@ -2,8 +2,12 @@
 
 set -e
 
-SCRIPT_DIR="$(dirname "$0")"
-RELEASE_ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+SCRIPT=$(readlink $0)
+if [ -z $SCRIPT ]; then
+    SCRIPT=$0
+fi;
+SCRIPT_DIR="$(cd `dirname "$SCRIPT"` && pwd -P)"
+RELEASE_ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd -P)"
 REL_NAME="{{ rel_name }}"
 REL_VSN="{{ rel_vsn }}"
 ERTS_VSN="{{ erts_vsn }}"

--- a/priv/templates/extended_bin
+++ b/priv/templates/extended_bin
@@ -2,8 +2,12 @@
 
 set -e
 
-SCRIPT_DIR="$(dirname "$0")"
-RELEASE_ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+SCRIPT=$(readlink $0)
+if [ -z $SCRIPT ]; then
+    SCRIPT=$0
+fi;
+SCRIPT_DIR="$(cd `dirname "$SCRIPT"` && pwd -P)"
+RELEASE_ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd -P)"
 REL_NAME="{{ rel_name }}"
 REL_VSN="{{ rel_vsn }}"
 ERTS_VSN="{{ erts_vsn }}"
@@ -89,9 +93,7 @@ relx_start_command() {
 if [ -z "$VMARGS_PATH" ]; then
     if [ -f "$RELEASE_ROOT_DIR/vm.args" ]; then
         VMARGS_PATH="$RELEASE_ROOT_DIR/vm.args"
-        USE_DIR="$RELEASE_ROOT_DIR"
     else
-        USE_DIR="$REL_DIR"
         VMARGS_PATH="$REL_DIR/vm.args"
     fi
 fi
@@ -104,9 +106,10 @@ fi
 # Make sure log directory exists
 mkdir -p "$RUNNER_LOG_DIR"
 
+# Use $CWD/sys.config if exists, otherwise releases/VSN/sys.config
 if [ -z "$RELX_CONFIG_PATH" ]; then
-    if [ -f "$USE_DIR/sys.config" ]; then
-        RELX_CONFIG_PATH="$USE_DIR/sys.config"
+    if [ -f "$RELEASE_ROOT_DIR/sys.config" ]; then
+        RELX_CONFIG_PATH="$RELEASE_ROOT_DIR/sys.config"
     else
         RELX_CONFIG_PATH="$REL_DIR/sys.config"
     fi


### PR DESCRIPTION
- Made the standard and extended startup scripts self-link-aware. This helps
  with deployments that symlink the startup script to more standard
  directories (i.e. /usr/local/bin). readlink is used, which comes
  standard in all Unix-like distributions
- Made the inclusion of a custom sys.config not depend on a custom
  vm.args file. This way you can use a custom sys.config without using
  a custom vm.args file