### PR TITLE
update erlware_commons, remove unneeded 'v' prefix hack

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,6 +1,6 @@
 %% -*- mode: Erlang; fill-column: 80; comment-column: 75; -*-
 %% Dependencies ================================================================
-{deps, [{erlware_commons, "0.15.0"},
+{deps, [{erlware_commons, "0.16.0"},
         {providers, "1.4.1"},
         {getopt, "0.8.2"},
         {bbmustache, "1.0.3"}

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,4 +1,4 @@
 [{<<"bbmustache">>,{pkg,<<"bbmustache">>,<<"1.0.3">>},0},
- {<<"erlware_commons">>,{pkg,<<"erlware_commons">>,<<"0.15.0">>},0},
+ {<<"erlware_commons">>,{pkg,<<"erlware_commons">>,<<"0.16.0">>},0},
  {<<"getopt">>,{pkg,<<"getopt">>,<<"0.8.2">>},0},
  {<<"providers">>,{pkg,<<"providers">>,<<"1.4.1">>},0}].

--- a/src/relx.app.src
+++ b/src/relx.app.src
@@ -1,6 +1,6 @@
 {application,relx,
              [{description,"Release assembler for Erlang/OTP Releases"},
-              {vsn,"3.5.0"},
+              {vsn,"git"},
               {modules,[]},
               {registered,[]},
               {applications,[kernel,stdlib,getopt,erlware_commons,bbmustache,

--- a/src/rlx_config.erl
+++ b/src/rlx_config.erl
@@ -295,9 +295,10 @@ merge_configs([{Key, Value} | CliTerms], ConfigTerms) ->
     end.
 
 parse_vsn(Vsn) when Vsn =:= semver ; Vsn =:= "semver" ->
-    parse_vsn({semver, "v"});
-parse_vsn({semver, Prefix}) ->
-    {ok, V} = ec_git_vsn:vsn({Prefix}),
+    {ok, V} = ec_git_vsn:vsn([]),
+    V;
+parse_vsn({semver, _}) ->
+    {ok, V} = ec_git_vsn:vsn([]),
     V;
 parse_vsn({cmd, Command}) ->
     V = os:cmd(Command),


### PR DESCRIPTION
Also switched back to `"git"` for the vsn in the app file. I've updated the rebar3 hex plugin to support this and streamline the process of creating a new package version.