### PR TITLE
Add rpc|rpcterms to nodetool usage

### DIFF
--- a/priv/templates/nodetool
+++ b/priv/templates/nodetool
@@ -54,7 +54,7 @@ main(Args) ->
             end;
         Other ->
             io:format("Other: ~p\n", [Other]),
-            io:format("Usage: nodetool {ping|stop|restart|reboot}\n")
+            io:format("Usage: nodetool {ping|stop|restart|reboot|rpc|rpcterms} [RPC]\n")
     end,
     net_kernel:stop().
 


### PR DESCRIPTION
Tiny change to usage. Got bitten earlier today, made me think rpcterms wasn't possible.