### PR TITLE
'-f' allows release to start even if script is _not_ a symlink

### DIFF
--- a/priv/templates/bin
+++ b/priv/templates/bin
@@ -2,7 +2,7 @@
 
 set -e
 
-SCRIPT=$(readlink $0)
+SCRIPT=$(readlink -f $0)
 if [ -z $SCRIPT ]; then
     SCRIPT=$0
 fi;

--- a/priv/templates/extended_bin
+++ b/priv/templates/extended_bin
@@ -2,7 +2,7 @@
 
 set -e
 
-SCRIPT=$(readlink $0)
+SCRIPT=$(readlink -f $0)
 if [ -z $SCRIPT ]; then
     SCRIPT=$0
 fi;


### PR DESCRIPTION
If the start script is invoked directly (ie, not as a symlink) then nothing happens!
Let's fix that.