### PR TITLE
Regression fix on startup script improvements

### DIFF
--- a/priv/templates/bin
+++ b/priv/templates/bin
@@ -2,7 +2,7 @@
 
 set -e
 
-SCRIPT=$(readlink $0)
+SCRIPT=$(readlink $0 || true)
 if [ -z $SCRIPT ]; then
     SCRIPT=$0
 fi;

--- a/priv/templates/extended_bin
+++ b/priv/templates/extended_bin
@@ -2,7 +2,7 @@
 
 set -e
 
-SCRIPT=$(readlink $0)
+SCRIPT=$(readlink $0 || true)
 if [ -z $SCRIPT ]; then
     SCRIPT=$0
 fi;


### PR DESCRIPTION
Fixed a regression that occurs when using readlink on a Mac, which crashes the startup script if the startup script is not a link but an actual file (which is the most common case). Resolves #394 