### PR TITLE
make short name the default in vmargs

### DIFF
--- a/priv/templates/vm_args
+++ b/priv/templates/vm_args
@@ -1,5 +1,5 @@
 ## Name of the node
--name {{ rel_name }}@127.0.0.1
+-sname {{ rel_name }}
 
 ## Cookie for distributed erlang
 -setcookie {{ rel_name }}


### PR DESCRIPTION
Better default. More likely that the long name doesn't work for someone than the short name.