### PR TITLE
fix upgrade/install/unpack command bug

### DIFF
--- a/priv/templates/extended_bin
+++ b/priv/templates/extended_bin
@@ -297,7 +297,7 @@ case "$1" in
         fi
 
         exec "$BINDIR/escript" "$ROOTDIR/bin/install_upgrade.escript" \
-             "install" "$REL_NAME" "$NAME" "$COOKIE" "$2"
+             "install" "$REL_NAME" "$NAME_TYPE" "$NAME" "$COOKIE" "$2"
         ;;
 
     unpack)
@@ -315,7 +315,7 @@ case "$1" in
         fi
 
         exec "$BINDIR/escript" "$ROOTDIR/bin/install_upgrade.escript" \
-             "unpack" "$REL_NAME" "$NAME" "$COOKIE" "$2"
+             "unpack" "$REL_NAME" "$NAME_TYPE" "$NAME" "$COOKIE" "$2"
         ;;
 
     console|console_clean|console_boot)

--- a/priv/templates/install_upgrade_escript
+++ b/priv/templates/install_upgrade_escript
@@ -7,8 +7,8 @@
 -define(INFO(Fmt,Args), io:format(Fmt,Args)).
 
 %% Unpack or upgrade to a new tar.gz release
-main(["unpack", RelName, NodeName, Cookie, VersionArg]) ->
-    TargetNode = start_distribution(NodeName, Cookie),
+main(["unpack", RelName, NameTypeArg, NodeName, Cookie, VersionArg]) ->
+    TargetNode = start_distribution(NodeName, NameTypeArg, Cookie),
     WhichReleases = which_releases(TargetNode),
     Version = parse_version(VersionArg),
     case proplists:get_value(Version, WhichReleases) of
@@ -35,8 +35,8 @@ main(["unpack", RelName, NodeName, Cookie, VersionArg]) ->
         permanent ->
             ?INFO("Release ~s is already installed, and set permanent.~n",[Version])
     end;
-main(["install", RelName, NodeName, Cookie, VersionArg]) ->
-    TargetNode = start_distribution(NodeName, Cookie),
+main(["install", RelName, NameTypeArg, NodeName, Cookie, VersionArg]) ->
+    TargetNode = start_distribution(NodeName, NameTypeArg, Cookie),
     WhichReleases = which_releases(TargetNode),
     Version = parse_version(VersionArg),
     case proplists:get_value(Version, WhichReleases) of
@@ -112,9 +112,9 @@ print_existing_versions(TargetNode) ->
             ||  {V,S} <- which_releases(TargetNode) ]),
     ?INFO("Installed versions:~n~s", [VerList]).
 
-start_distribution(NodeName, Cookie) ->
+start_distribution(NodeName, NameTypeArg, Cookie) ->
     MyNode = make_script_node(NodeName),
-    {ok, _Pid} = net_kernel:start([MyNode, longnames]),
+    {ok, _Pid} = net_kernel:start([MyNode, get_name_type(NameTypeArg)]),
     erlang:set_cookie(node(), list_to_atom(Cookie)),
     TargetNode = list_to_atom(NodeName),
     case {net_kernel:connect_node(TargetNode),
@@ -132,3 +132,12 @@ start_distribution(NodeName, Cookie) ->
 make_script_node(Node) ->
     [Name, Host] = string:tokens(Node, "@"),
     list_to_atom(lists:concat([Name, "_upgrader_", os:getpid(), "@", Host])).
+
+%% get name type from arg
+get_name_type(NameTypeArg) ->
+	case NameTypeArg of
+		"-sname" ->
+			shortnames;
+		_ ->
+			longnames
+	end.


### PR DESCRIPTION
bug description:
  if vm.arg use '-sname xxx' option, When exec upgrade/install/unpack command, it will report "Hostname yyy is illegal" error.