### PR TITLE
pass node name type to install_upgrade escript for net_kernel start

### DIFF
--- a/priv/templates/extended_bin
+++ b/priv/templates/extended_bin
@@ -297,7 +297,7 @@ case "$1" in
         fi
 
         exec "$BINDIR/escript" "$ROOTDIR/bin/install_upgrade.escript" \
-             "install" "$REL_NAME" "$NAME" "$COOKIE" "$2"
+             "install" "$REL_NAME" "$NAME_TYPE" "$NAME" "$COOKIE" "$2"
         ;;
 
     unpack)
@@ -315,7 +315,7 @@ case "$1" in
         fi
 
         exec "$BINDIR/escript" "$ROOTDIR/bin/install_upgrade.escript" \
-             "unpack" "$REL_NAME" "$NAME" "$COOKIE" "$2"
+             "unpack" "$REL_NAME" "$NAME_TYPE" "$NAME" "$COOKIE" "$2"
         ;;
 
     console|console_clean|console_boot)

--- a/priv/templates/install_upgrade_escript
+++ b/priv/templates/install_upgrade_escript
@@ -7,8 +7,8 @@
 -define(INFO(Fmt,Args), io:format(Fmt,Args)).
 
 %% Unpack or upgrade to a new tar.gz release
-main(["unpack", RelName, NodeName, Cookie, VersionArg]) ->
-    TargetNode = start_distribution(NodeName, Cookie),
+main(["unpack", RelName, NodeType, NodeName, Cookie, VersionArg]) ->
+    TargetNode = start_distribution(NodeType, NodeName, Cookie),
     WhichReleases = which_releases(TargetNode),
     Version = parse_version(VersionArg),
     case proplists:get_value(Version, WhichReleases) of
@@ -35,8 +35,8 @@ main(["unpack", RelName, NodeName, Cookie, VersionArg]) ->
         permanent ->
             ?INFO("Release ~s is already installed, and set permanent.~n",[Version])
     end;
-main(["install", RelName, NodeName, Cookie, VersionArg]) ->
-    TargetNode = start_distribution(NodeName, Cookie),
+main(["install", RelName, NodeType, NodeName, Cookie, VersionArg]) ->
+    TargetNode = start_distribution(NodeType, NodeName, Cookie),
     WhichReleases = which_releases(TargetNode),
     Version = parse_version(VersionArg),
     case proplists:get_value(Version, WhichReleases) of
@@ -112,9 +112,14 @@ print_existing_versions(TargetNode) ->
             ||  {V,S} <- which_releases(TargetNode) ]),
     ?INFO("Installed versions:~n~s", [VerList]).
 
-start_distribution(NodeName, Cookie) ->
+start_distribution("-name", NodeName, Cookie) ->
+    start_distribution_(longnames, NodeName, Cookie);
+start_distribution("-sname", NodeName, Cookie) ->
+    start_distribution_(shortnames, NodeName, Cookie).
+
+start_distribution_(Type, NodeName, Cookie) ->
     MyNode = make_script_node(NodeName),
-    {ok, _Pid} = net_kernel:start([MyNode, longnames]),
+    {ok, _Pid} = net_kernel:start([MyNode, Type]),
     erlang:set_cookie(node(), list_to_atom(Cookie)),
     TargetNode = list_to_atom(NodeName),
     case {net_kernel:connect_node(TargetNode),


### PR DESCRIPTION
This fixes an issue with when a shortname is used to start a node and then the user wants to use install or upgrade.