### PR TITLE
support overriding config values with per-release config values

### DIFF
--- a/src/rlx_prv_release.erl
+++ b/src/rlx_prv_release.erl
@@ -164,6 +164,10 @@ solve_release(State0, DepGraph, RelName, RelVsn) ->
                 {ok, Release0} ->
                     rlx_release:relfile(rlx_state:get_configured_release(State0, RelName, RelVsn), rlx_release:relfile(Release0))
             end,
+
+        %% get per release config values and override the State with them
+        Config = rlx_release:config(Release),
+        {ok, State1} = lists:foldl(fun rlx_config:load_terms/2, {ok, State0}, Config),
         Goals = rlx_release:goals(Release),
         case Goals of
             [] ->
@@ -171,7 +175,7 @@ solve_release(State0, DepGraph, RelName, RelVsn) ->
             _ ->
                 case rlx_depsolver:solve(DepGraph, Goals) of
                     {ok, Pkgs} ->
-                        set_resolved(State0, Release, Pkgs);
+                        set_resolved(State1, Release, Pkgs);
                     {error, Error} ->
                         ?RLX_ERROR({failed_solve, Error})
                 end

--- a/src/rlx_release.erl
+++ b/src/rlx_release.erl
@@ -40,6 +40,8 @@
          metadata/1,
          start_clean_metadata/1,
          canonical_name/1,
+         config/1,
+         config/2,
          format/1,
          format/2,
          format_error/1]).
@@ -63,7 +65,8 @@
                     annotations = undefined :: annotations(),
                     applications = [] ::  [application_spec()],
                     relfile :: undefined | string(),
-                    app_detail = [] :: [rlx_app_info:t()]}).
+                    app_detail = [] :: [rlx_app_info:t()],
+                    config = []}).
 
 %%============================================================================
 %% types
@@ -200,6 +203,15 @@ start_clean_metadata(#release_t{name=Name, vsn=Vsn, erts=ErtsVsn, applications=A
 canonical_name(#release_t{name=Name, vsn=Vsn}) ->
     erlang:binary_to_list(erlang:iolist_to_binary([erlang:atom_to_list(Name), "-",
                                                    Vsn])).
+
+
+-spec config(t(), list()) -> t().
+config(Release, Config) ->
+    Release#release_t{config=Config}.
+
+-spec config(t()) -> list().
+config(#release_t{config=Config}) ->
+    Config.
 
 -spec format(t()) -> iolist().
 format(Release) ->


### PR DESCRIPTION
Before a release is assembled we now support config values that are per release to override the global relx config values, example:

```
{release, {rel_a, "0.1.0"}, [app_a]}.
{release, {rel_b, "0.1.0"}, [app_b], [{sys_config, "config/rel_b/sys.config"}]}.
{sys_config, "config/sys.config"}.
```

When building `rel_b` (like with `relx -n rel_b`) will use `config/rel_b/sys.config` while `rel_a` uses `config/sys.config`.