### PR TITLE
include lib dir if it exists, erl_interface is an ex. with a lib

### DIFF
--- a/src/rlx_prv_assembler.erl
+++ b/src/rlx_prv_assembler.erl
@@ -279,8 +279,7 @@ copy_directory(AppDir, TargetDir, IncludeSrc) ->
                   end, ["ebin",
                         "include",
                         "priv",
-                        "README",
-                        "LICENSE" |
+                        "lib" |
                         case IncludeSrc of
                             true ->
                                 ["src",


### PR DESCRIPTION
Fix for https://github.com/erlware/relx/issues/338