### PR TITLE
include cf in escript so output works

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -9,7 +9,7 @@
 {escript_incl_extra, [{"priv/templates/*", "."}]}.
 {escript_emu_args, "%%! +sbtu +A0 -noinput\n"}.
 {escript_incl_apps,
- [getopt, erlware_commons, bbmustache, providers]}.
+ [getopt, erlware_commons, cf, bbmustache, providers]}.
 
 %% Compiler Options ============================================================
 {erl_opts,

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,4 +1,5 @@
 [{<<"bbmustache">>,{pkg,<<"bbmustache">>,<<"1.0.4">>},0},
+ {<<"cf">>,{pkg,<<"cf">>,<<"0.2.1">>},1},
  {<<"erlware_commons">>,{pkg,<<"erlware_commons">>,<<"0.18.0">>},0},
  {<<"getopt">>,{pkg,<<"getopt">>,<<"0.8.2">>},0},
  {<<"providers">>,{pkg,<<"providers">>,<<"1.6.0">>},0}].


### PR DESCRIPTION
cf was not being included in the escript for relx which was causing it to crash when used.