### PR TITLE
replace last, not first when merging cli and config terms

### DIFF
--- a/src/rlx_config.erl
+++ b/src/rlx_config.erl
@@ -316,7 +316,7 @@ merge_configs([{Key, Value} | CliTerms], ConfigTerms) ->
                     merge_configs(CliTerms, ConfigTerms++[{Key, Value}])
             end;
         _ ->
-            merge_configs(CliTerms, lists:keystore(Key, 1, ConfigTerms, {Key, Value}))
+            merge_configs(CliTerms, lists:reverse(lists:keystore(Key, 1, lists:reverse(ConfigTerms), {Key, Value})))
     end.
 
 parse_vsn(Vsn) when Vsn =:= semver ; Vsn =:= "semver" ->


### PR DESCRIPTION
Ugly, but there is no 'keystorelast', so whatever.