### PR TITLE
Remove name collisions of replaced files in multi-node setups

### DIFF
--- a/priv/templates/extended_bin
+++ b/priv/templates/extended_bin
@@ -17,13 +17,12 @@ if [ "$TERM" = "dumb" -o -z "$TERM" ]; then
   export TERM=screen
 fi
 
-SCRIPT=$(readlink $0 || true)
-if [ -z $SCRIPT ]; then
-    SCRIPT=$0
-fi;
+SCRIPT=$(readlink -f $0 || true)
+[ -z $SCRIPT ] && SCRIPT=$0
 SCRIPT_DIR="$(cd `dirname "$SCRIPT"` && pwd -P)"
 RELEASE_ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd -P)"
-REL_NAME="{{ rel_name }}"
+# Make the value available to variable substitution calls below
+export REL_NAME="{{ rel_name }}"
 REL_VSN="{{ rel_vsn }}"
 ERTS_VSN="{{ erts_vsn }}"
 CODE_LOADING_MODE="${CODE_LOADING_MODE:-embedded}"
@@ -119,7 +118,9 @@ relx_get_pid() {
 
 relx_get_nodename() {
     id="longname$(relx_gen_id)-${NAME}"
-    "$BINDIR/erl" -boot start_clean -eval '[Host] = tl(string:tokens(atom_to_list(node()),"@")), io:format("~s~n", [Host]), halt()' -noshell ${NAME_TYPE} $id
+    "$BINDIR/erl" -boot start_clean \
+        -eval '[H]=tl(string:tokens(atom_to_list(node()),"@")), io:format("~s~n",[H]), halt()' \
+        -noshell ${NAME_TYPE} $id
 }
 
 # Connect to a remote node
@@ -174,7 +175,30 @@ relx_get_code_paths() {
     "$BINDIR/erl" -noshell -boot start_clean -eval "$code"
 }
 
-check_replace_os_vars() {
+make_out_file_path() {
+    # Use output directory provided in the RELX_OUT_FILE_PATH environment variable
+    # (default to the current location of vm.args and sys.config)
+    DIR=$(dirname $1)
+    [ -d "${RELX_OUT_FILE_PATH}" ] && DIR="${RELX_OUT_FILE_PATH}"
+    FILE=$(basename $1)
+    IN="${DIR}/${FILE}"
+
+    PFX=$(echo $IN   | awk '{sub(/\.[^.]+$/, "", $0)}1')
+    SFX=$(echo $FILE | awk -F . '{if (NF>1) print $NF}')
+    echo "${PFX}.${NAME}.${SFX}"
+}
+
+# Replace environment variables
+replace_os_vars() {
+    awk '{
+        while(match($0,"[$]{[^}]*}")) {
+            var=substr($0,RSTART+2,RLENGTH -3)
+            gsub("[$]{"var"}",ENVIRON[var])
+        }
+    }1' < "$1" > "$2"
+}
+
+add_path() {
     # Use $CWD/$1 if exists, otherwise releases/VSN/$1
     IN_FILE_PATH=$2
     if [ -z "$IN_FILE_PATH" ]; then
@@ -184,12 +208,16 @@ check_replace_os_vars() {
             IN_FILE_PATH="$REL_DIR/$1"
         fi
     fi
+    echo $IN_FILE_PATH
+}
 
+check_replace_os_vars() {
+    IN_FILE_PATH=$(add_path $1 $2)
     OUT_FILE_PATH="$IN_FILE_PATH"
     ORIG_FILE_PATH="$IN_FILE_PATH.orig"
     if [ $RELX_REPLACE_OS_VARS ]; then
-        # Create a new file in /tmp
-        OUT_FILE_PATH=$(mktemp /tmp/XXXXXX.$REL_NAME.$1)
+        # Create a new file in the same location as original
+        OUT_FILE_PATH=$(make_out_file_path $IN_FILE_PATH)
         # If vm.args.orig or sys.config.orig is present then use that
         if [ -f "$ORIG_FILE_PATH" ]; then
            IN_FILE_PATH="$ORIG_FILE_PATH"
@@ -197,7 +225,7 @@ check_replace_os_vars() {
 
         # apply the environment variable substitution to $IN_FILE_PATH
         # the result is saved to $OUT_FILE_PATH
-        awk '{while(match($0,"[$]{[^}]*}")) {var=substr($0,RSTART+2,RLENGTH -3);gsub("[$]{"var"}",ENVIRON[var])}}1' < "$IN_FILE_PATH" > "$OUT_FILE_PATH"
+        replace_os_vars "$IN_FILE_PATH" "$OUT_FILE_PATH"
     else
         # If vm.arg.orig or sys.config.orig is present then use that
         if [ -f "$ORIG_FILE_PATH" ]; then
@@ -207,14 +235,12 @@ check_replace_os_vars() {
     echo $OUT_FILE_PATH
 }
 
-VMARGS_PATH=$(check_replace_os_vars vm.args $VMARGS_PATH)
-RELX_CONFIG_PATH=$(check_replace_os_vars sys.config $RELX_CONFIG_PATH)
-
-# Make sure log directory exists
-mkdir -p "$RUNNER_LOG_DIR"
-
+VMARGS_PATH=$(add_path vm.args $VMARGS_PATH)
 # Extract the target node name from node.args
 NAME_ARG=$(egrep '^-s?name' "$VMARGS_PATH" || true)
+# Perform replacement of variables in ${NAME_ARG}
+NAME_ARG=$(eval echo "${NAME_ARG}")
+
 if [ -z "$NAME_ARG" ]; then
     echo "vm.args needs to have either -name or -sname parameter."
     exit 1
@@ -223,6 +249,23 @@ fi
 # Extract the name type and name from the NAME_ARG for REMSH
 NAME_TYPE="$(echo "$NAME_ARG" | awk '{print $1}')"
 NAME="$(echo "$NAME_ARG" | awk '{print $2}')"
+
+# User can specify an sname without @hostname
+# This will fail when creating remote shell
+# So here we check for @ and add @hostname if missing
+case "${NAME}" in
+    *@*) ;;                             # Nothing to do
+    *)   NAME=${NAME}@$(hostname -s);;  # Add @hostname
+esac
+
+# Export the variable so that it's available in the 'eval' calls
+export NAME
+
+VMARGS_PATH=$(check_replace_os_vars vm.args $VMARGS_PATH)
+RELX_CONFIG_PATH=$(check_replace_os_vars sys.config $RELX_CONFIG_PATH)
+
+# Make sure log directory exists
+mkdir -p "$RUNNER_LOG_DIR"
 
 PIPE_DIR="${PIPE_DIR:-/tmp/erl_pipes/$NAME/}"
 
@@ -247,21 +290,9 @@ export BINDIR="$ERTS_DIR/bin"
 export EMU="beam"
 export PROGNAME="erl"
 export LD_LIBRARY_PATH="$ERTS_DIR/lib:$LD_LIBRARY_PATH"
-ERTS_LIB_DIR="$ERTS_DIR/../lib"
+ERTS_LIB_DIR="$(dirname "$ERTS_DIR")/lib"
 
 cd "$ROOTDIR"
-
-# User can specify an sname without @hostname
-# This will fail when creating remote shell
-# So here we check for @ and add @hostname if missing
-case $NAME in
-    *@*)
-        # Nothing to do
-        ;;
-    *)
-        NAME=$NAME@$(relx_get_nodename)
-        ;;
-esac
 
 # Check the first argument for instructions
 case "$1" in

--- a/test/rlx_test_utils.erl
+++ b/test/rlx_test_utils.erl
@@ -110,3 +110,7 @@ list_to_term(String) ->
         {error, Error} ->
             Error
     end.
+
+unescape_string(String) ->
+    re:replace(String, "\"", "",
+               [global, {return, list}]).


### PR DESCRIPTION
Generated vm.2.args and sys.2.config files are renamed to `vm.${NAME}.args` and `sys.${NAME}.config` to avoid naming collisions in the multi-node startup off of the same release dir.
