### PR TITLE
Include src/ in tarballs unless specified not to

### DIFF
--- a/src/rlx_prv_archive.erl
+++ b/src/rlx_prv_archive.erl
@@ -67,7 +67,7 @@ make_tar(State, Release, OutputDir) ->
     Vsn = rlx_release:vsn(Release),
     ErtsVersion = rlx_release:erts(Release),
     Opts = [{path, [filename:join([OutputDir, "lib", "*", "ebin"])]},
-            {dirs, [include]},
+            {dirs, [include | maybe_src_dirs(State)]},
             {outdir, OutputDir} |
             case rlx_state:get(State, include_erts, true) of
                 true ->
@@ -170,3 +170,10 @@ filter({template, _, _}) ->
     true;
 filter(_) ->
     false.
+
+maybe_src_dirs(State) ->
+    case rlx_state:get(State, include_src, true) of
+        false -> [];
+        true -> [src]
+    end.
+

--- a/test/rlx_archive_SUITE.erl
+++ b/test/rlx_archive_SUITE.erl
@@ -8,7 +8,9 @@
          init_per_testcase/2,
          all/0,
          basic_tar/1,
-         exclude_erts/1]).
+         exclude_erts/1,
+         exclude_src/1,
+         include_src/1]).
 
 -include_lib("common_test/include/ct.hrl").
 -include_lib("eunit/include/eunit.hrl").
@@ -33,7 +35,7 @@ init_per_testcase(_, Config) ->
      {state, State1} | Config].
 
 all() ->
-    [basic_tar, exclude_erts].
+    [basic_tar, exclude_erts, exclude_src, include_src].
 
 basic_tar(Config) ->
     LibDir1 = proplists:get_value(lib1, Config),
@@ -129,4 +131,99 @@ exclude_erts(Config) ->
     {ok, Files} = erl_tar:table(TarFile, [compressed]),
     ?assert(lists:all(fun(X) -> re:run(X, "lib/stdlib-.*/ebin/.*") =:= nomatch end, Files)),
     ?assert(lists:all(fun(X) -> re:run(X, "lib/kernel-.*/ebin/.*") =:= nomatch end, Files)),
+    ?assert(filelib:is_regular(TarFile)).
+
+exclude_src(Config) ->
+    LibDir1 = proplists:get_value(lib1, Config),
+    [(fun({Name, Vsn}) ->
+              rlx_test_utils:create_app(LibDir1, Name, Vsn, [kernel, stdlib], [])
+      end)(App)
+     ||
+        App <-
+            [{rlx_test_utils:create_random_name("lib_app1_"), rlx_test_utils:create_random_vsn()}
+             || _ <- lists:seq(1, 100)]],
+
+    rlx_test_utils:create_app(LibDir1, "goal_app_1", "0.0.1", [stdlib,kernel,non_goal_1], []),
+    rlx_test_utils:create_app(LibDir1, "lib_dep_1", "0.0.1", [stdlib,kernel], []),
+    rlx_test_utils:create_app(LibDir1, "goal_app_2", "0.0.1", [stdlib,kernel,goal_app_1,non_goal_2], []),
+    rlx_test_utils:create_app(LibDir1, "non_goal_1", "0.0.1", [stdlib,kernel], [lib_dep_1]),
+    rlx_test_utils:create_app(LibDir1, "non_goal_2", "0.0.1", [stdlib,kernel], []),
+
+    ConfigFile = filename:join([LibDir1, "relx.config"]),
+    rlx_test_utils:write_config(ConfigFile,
+                                [{release, {foo, "0.0.1"},
+                                  [goal_app_1,
+                                   goal_app_2]},
+                                 {include_src, false}]),
+    OutputDir = filename:join([proplists:get_value(data_dir, Config),
+                               rlx_test_utils:create_random_name("relx-output")]),
+    {ok, State} = relx:do([{relname, foo},
+                           {relvsn, "0.0.1"},
+                           {goals, []},
+                           {lib_dirs, [LibDir1]},
+                           {log_level, 3},
+                           {output_dir, OutputDir},
+                           {config, ConfigFile}], ["release", "tar"]),
+
+    [{{foo, "0.0.1"}, Release}] = ec_dictionary:to_list(rlx_state:realized_releases(State)),
+    AppSpecs = rlx_release:applications(Release),
+    ?assert(lists:keymember(stdlib, 1, AppSpecs)),
+    ?assert(lists:keymember(kernel, 1, AppSpecs)),
+    ?assert(lists:member({non_goal_1, "0.0.1"}, AppSpecs)),
+    ?assert(lists:member({non_goal_2, "0.0.1"}, AppSpecs)),
+    ?assert(lists:member({goal_app_1, "0.0.1"}, AppSpecs)),
+    ?assert(lists:member({goal_app_2, "0.0.1"}, AppSpecs)),
+    ?assert(lists:member({lib_dep_1, "0.0.1", load}, AppSpecs)),
+
+    TarFile = filename:join([OutputDir, "foo", "foo-0.0.1.tar.gz"]),
+    {ok, Files} = erl_tar:table(TarFile, [compressed]),
+    ?assert(lists:any(fun(X) -> re:run(X, "lib/stdlib-.*/src/.*") =:= nomatch end, Files)),
+    ?assert(lists:any(fun(X) -> re:run(X, "lib/kernel-.*/src/.*") =:= nomatch end, Files)),
+    ?assert(filelib:is_regular(TarFile)).
+
+include_src(Config) ->
+    LibDir1 = proplists:get_value(lib1, Config),
+    [(fun({Name, Vsn}) ->
+              rlx_test_utils:create_app(LibDir1, Name, Vsn, [kernel, stdlib], [])
+      end)(App)
+     ||
+        App <-
+            [{rlx_test_utils:create_random_name("lib_app1_"), rlx_test_utils:create_random_vsn()}
+             || _ <- lists:seq(1, 100)]],
+
+    rlx_test_utils:create_app(LibDir1, "goal_app_1", "0.0.1", [stdlib,kernel,non_goal_1], []),
+    rlx_test_utils:create_app(LibDir1, "lib_dep_1", "0.0.1", [stdlib,kernel], []),
+    rlx_test_utils:create_app(LibDir1, "goal_app_2", "0.0.1", [stdlib,kernel,goal_app_1,non_goal_2], []),
+    rlx_test_utils:create_app(LibDir1, "non_goal_1", "0.0.1", [stdlib,kernel], [lib_dep_1]),
+    rlx_test_utils:create_app(LibDir1, "non_goal_2", "0.0.1", [stdlib,kernel], []),
+
+    ConfigFile = filename:join([LibDir1, "relx.config"]),
+    rlx_test_utils:write_config(ConfigFile,
+                                [{release, {foo, "0.0.1"},
+                                  [goal_app_1,
+                                   goal_app_2]}]),
+    OutputDir = filename:join([proplists:get_value(data_dir, Config),
+                               rlx_test_utils:create_random_name("relx-output")]),
+    {ok, State} = relx:do([{relname, foo},
+                           {relvsn, "0.0.1"},
+                           {goals, []},
+                           {lib_dirs, [LibDir1]},
+                           {log_level, 3},
+                           {output_dir, OutputDir},
+                           {config, ConfigFile}], ["release", "tar"]),
+
+    [{{foo, "0.0.1"}, Release}] = ec_dictionary:to_list(rlx_state:realized_releases(State)),
+    AppSpecs = rlx_release:applications(Release),
+    ?assert(lists:keymember(stdlib, 1, AppSpecs)),
+    ?assert(lists:keymember(kernel, 1, AppSpecs)),
+    ?assert(lists:member({non_goal_1, "0.0.1"}, AppSpecs)),
+    ?assert(lists:member({non_goal_2, "0.0.1"}, AppSpecs)),
+    ?assert(lists:member({goal_app_1, "0.0.1"}, AppSpecs)),
+    ?assert(lists:member({goal_app_2, "0.0.1"}, AppSpecs)),
+    ?assert(lists:member({lib_dep_1, "0.0.1", load}, AppSpecs)),
+
+    TarFile = filename:join([OutputDir, "foo", "foo-0.0.1.tar.gz"]),
+    {ok, Files} = erl_tar:table(TarFile, [compressed]),
+    ?assert(lists:any(fun(X) -> re:run(X, "lib/stdlib-.*/src/.*") =/= nomatch end, Files)),
+    ?assert(lists:any(fun(X) -> re:run(X, "lib/kernel-.*/src/.*") =/= nomatch end, Files)),
     ?assert(filelib:is_regular(TarFile)).


### PR DESCRIPTION
By default, the `include_src` value is `true`, yet Relx disregards the
value entirely when generating tarballs.

This patch makes it so the value is used and respected when generating
tarballs. Given the default value is `true`, this patch changes the
default behaviour of relx to always include source files in tarballs,
considering its omission a bug rather than a feature.

Tests are added, verifying the impact on ERTS-included files.