### PR TITLE
move missing beam and other app warnings to debug messages

### DIFF
--- a/src/rlx_app_discovery.erl
+++ b/src/rlx_app_discovery.erl
@@ -85,7 +85,7 @@ get_app_metadata(State, LibDirs) ->
                             {ok, _} = AppMeta ->
                                 [AppMeta|Acc];
                             {warning, W} ->
-                                ec_cmd_log:warn(rlx_state:log(State), format_detail(W)),
+                                ec_cmd_log:debug(rlx_state:log(State), format_detail(W)),
                                 Acc;
                             {error, E} ->
                                 ec_cmd_log:error(rlx_state:log(State), format_detail(E)),
@@ -111,7 +111,7 @@ resolve_app_metadata(State, LibDirs) ->
                  {error, _} ->
                      true;
                  {warning, W} ->
-                     ec_cmd_log:warn(rlx_state:log(State), format_detail(W)),
+                     ec_cmd_log:debug(rlx_state:log(State), format_detail(W)),
                      false;
                  _ ->
                      false

--- a/src/rlx_app_discovery.erl
+++ b/src/rlx_app_discovery.erl
@@ -164,7 +164,7 @@ resolve_override(AppName, FileName0) ->
 
 -spec format_detail(ErrorDetail::term()) -> iolist().
 format_detail({missing_beam_file, Module, BeamFile}) ->
-    io_lib:format("Missing beam file ~p ~p", [Module, BeamFile]);
+    io_lib:format("Missing beam file ~p ~s", [Module, BeamFile]);
 format_detail({error, {invalid_override, AppName, FileName}}) ->
     io_lib:format("Override {~p, ~p} is not a valid OTP App. Perhaps you forgot to build it?",
                   [AppName, FileName]);


### PR DESCRIPTION
These warnings have been really confusing to people, especially since they are usually about apps that aren't even being included in the user's release. So in this patch I change them to debug messages, the user won't see them until they are actively debugging an issue.