### PR TITLE
replacing OS vars: comply with otp sys.config requirement

### DIFF
--- a/priv/templates/bin
+++ b/priv/templates/bin
@@ -32,6 +32,11 @@ find_sys_config() {
     __possible_sys="$REL_DIR/sys.config"
     if [ -f "$__possible_sys" ]; then
         SYS_CONFIG="$__possible_sys"
+    else 
+       if [ -L "$__possible_sys".orig ]; then
+          mv "$__possible_sys".orig "$__possible_sys"  
+          SYS_CONFIG="$__possible_sys"
+       fi
     fi
 }
 
@@ -39,6 +44,11 @@ find_vm_args() {
     __possible_vm_args="$REL_DIR/vm.args"
     if [ -f "$__possible_vm_args" ]; then
         VM_ARGS="$__possible_vm_args"
+    else 
+       if [ -L "$__possible_vm_args".orig ]; then
+          mv "$__possible_vm_args".orig "$__possible_vm_args"  
+          VM_ARGS="$__possible_vm_args"
+       fi
     fi
 }
 

--- a/priv/templates/bin_windows
+++ b/priv/templates/bin_windows
@@ -73,6 +73,13 @@ cd %rootdir%
 @if exist "%possible_sys%" (
   set sys_config=-config "%possible_sys%"
 )
+@if exist "%possible_sys%".orig (
+  ren "%possible_sys%".orig "%possible_sys%" 
+  set sys_config=-config "%possible_sys%"
+)
+@if exist "%rel_dir%\vm.args".orig (
+  ren "%rel_dir%\vm.args" ".orig %rel_dir%\vm.args"
+)
 @goto :eof
 
 :: set boot_script variable

--- a/priv/templates/extended_bin
+++ b/priv/templates/extended_bin
@@ -116,8 +116,11 @@ if [ -z "$RELX_CONFIG_PATH" ]; then
 fi
 
 if [ $RELX_REPLACE_OS_VARS ]; then
-    awk '{while(match($0,"[$]{[^}]*}")) {var=substr($0,RSTART+2,RLENGTH -3);gsub("[$]{"var"}",ENVIRON[var])}}1' < $RELX_CONFIG_PATH > $RELX_CONFIG_PATH.2.config
-    RELX_CONFIG_PATH=$RELX_CONFIG_PATH.2.config
+    #Make sure we don't break dev mode by keeping the symbolic link
+    orig_relx_config_path="$RELX_CONFIG_PATH.orig"
+    mv "$RELX_CONFIG_PATH" "$orig_relx_config_path"
+
+    awk '{while(match($0,"[$]{[^}]*}")) {var=substr($0,RSTART+2,RLENGTH -3);gsub("[$]{"var"}",ENVIRON[var])}}1' < "$orig_relx_config_path" > "$RELX_CONFIG_PATH"
 fi
 
 # Extract the target node name from node.args

--- a/priv/templates/extended_bin
+++ b/priv/templates/extended_bin
@@ -98,9 +98,23 @@ if [ -z "$VMARGS_PATH" ]; then
     fi
 fi
 
+orig_vmargs_path="$VMARGS_PATH.orig"
 if [ $RELX_REPLACE_OS_VARS ]; then
-    awk '{while(match($0,"[$]{[^}]*}")) {var=substr($0,RSTART+2,RLENGTH -3);gsub("[$]{"var"}",ENVIRON[var])}}1' < $VMARGS_PATH > $VMARGS_PATH.2.config
-    VMARGS_PATH=$VMARGS_PATH.2.config
+    #Make sure we don't break dev mode by keeping the symbolic link to 
+    #the user's vm.args
+    if [ ! -L "$orig_vmargs_path" ]; then
+       #we're in copy mode, rename the vm.args file to vm.args.orig
+       mv "$VMARGS_PATH" "$orig_vmargs_path"
+    fi
+
+    awk '{while(match($0,"[$]{[^}]*}")) {var=substr($0,RSTART+2,RLENGTH -3);gsub("[$]{"var"}",ENVIRON[var])}}1' < "$orig_vmargs_path" > "$VMARGS_PATH"
+ else
+    #We don't need to replace env. vars, just rename the
+    #symlink vm.args.orig to vm.args, and keep it as a
+    #symlink.
+    if [ -L "$orig_vmargs_path" ]; then
+       mv "$orig_vmargs_path" "$VMARGS_PATH" 
+    fi
 fi
 
 # Make sure log directory exists
@@ -115,12 +129,23 @@ if [ -z "$RELX_CONFIG_PATH" ]; then
     fi
 fi
 
+orig_relx_config_path="$RELX_CONFIG_PATH.orig"
 if [ $RELX_REPLACE_OS_VARS ]; then
-    #Make sure we don't break dev mode by keeping the symbolic link
-    orig_relx_config_path="$RELX_CONFIG_PATH.orig"
-    mv "$RELX_CONFIG_PATH" "$orig_relx_config_path"
+    #Make sure we don't break dev mode by keeping the symbolic link to 
+    #the user's sys.config
+    if [ ! -L "$orig_relx_config_path" ]; then
+       #We're in copy mode, rename sys.config to sys.config.orig
+       mv "$RELX_CONFIG_PATH" "$orig_relx_config_path"
+    fi
 
     awk '{while(match($0,"[$]{[^}]*}")) {var=substr($0,RSTART+2,RLENGTH -3);gsub("[$]{"var"}",ENVIRON[var])}}1' < "$orig_relx_config_path" > "$RELX_CONFIG_PATH"
+ else
+    #We don't need to replace env. vars, just rename the
+    #symlink sys.config.orig to sys.config. Keep it as 
+    #a symlink.
+    if [ -L "$orig_relx_config_path" ]; then
+       mv "$orig_relx_config_path"  "$RELX_CONFIG_PATH"
+    fi
 fi
 
 # Extract the target node name from node.args

--- a/src/rlx_prv_assembler.erl
+++ b/src/rlx_prv_assembler.erl
@@ -454,7 +454,7 @@ copy_or_symlink_config_file(State, ConfigPath, RelConfPath) ->
     ensure_not_exist(RelConfPath),
     case rlx_state:dev_mode(State) of
         true ->
-            ok = rlx_util:symlink_or_copy(ConfigPath, RelConfPath);
+            ok = rlx_util:symlink_or_copy(ConfigPath, RelConfPath ++ ".orig");
         _ ->
             ok = ec_file:copy(ConfigPath, RelConfPath)
     end.

--- a/test/rlx_release_SUITE.erl
+++ b/test/rlx_release_SUITE.erl
@@ -869,9 +869,9 @@ make_dev_mode_release(Config) ->
             ?assert(ec_file:is_symlink(filename:join([OutputDir, "foo", "lib", "goal_app_2-0.0.1"]))),
             ?assert(ec_file:is_symlink(filename:join([OutputDir, "foo", "lib", "lib_dep_1-0.0.1"]))),
             ?assert(ec_file:is_symlink(filename:join([OutputDir, "foo", "releases", "0.0.1",
-                                                      "sys.config"]))),
+                                                      "sys.config.orig"]))),
             ?assert(ec_file:is_symlink(filename:join([OutputDir, "foo", "releases", "0.0.1",
-                                                      "vm.args"])));
+                                                      "vm.args.orig"])));
         {win32, _} ->
             ?assert(filelib:is_dir(filename:join([OutputDir, "foo", "lib", "non_goal_1-0.0.1"]))),
             ?assert(filelib:is_dir(filename:join([OutputDir, "foo", "lib", "non_goal_2-0.0.1"]))),


### PR DESCRIPTION
I also enclosed vars in quotes to prevent problems with directories that have spaces in them. But this  is probably needed in other parts of the script too.