### PR TITLE
Add support for new relx directive that provides start/stop script hooks

### DIFF
--- a/priv/templates/builtin_hook_pid
+++ b/priv/templates/builtin_hook_pid
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# loop until the VM starts responding to pings
+while ! $(relx_nodetool "ping">/dev/null)
+do
+    sleep 1
+done
+
+# get the beam pid and write it to the file passed as
+# argument
+PID="$(relx_get_pid)"
+echo $PID > $1

--- a/priv/templates/builtin_hook_wait_for_process
+++ b/priv/templates/builtin_hook_wait_for_process
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# loop until the VM starts responding to pings
+while ! $(relx_nodetool "ping">/dev/null)
+do
+    sleep 1
+done
+
+# loop until the name provided as argument gets
+# registered
+while true
+do
+    if [ "$(relx_nodetool eval "whereis($1).")" != "undefined" ]
+    then
+        break
+    fi
+done

--- a/priv/templates/builtin_hook_wait_for_vm_start
+++ b/priv/templates/builtin_hook_wait_for_vm_start
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# loop until the VM starts responding to pings
+while ! $(relx_nodetool "ping">/dev/null)
+do
+    sleep 1
+done

--- a/priv/templates/extended_bin
+++ b/priv/templates/extended_bin
@@ -30,6 +30,14 @@ REL_DIR="$RELEASE_ROOT_DIR/releases/$REL_VSN"
 ERL_OPTS="{{ erl_opts }}"
 RUNNER_LOG_DIR="${RUNNER_LOG_DIR:-$RELEASE_ROOT_DIR/log}"
 
+# start/stop/install/upgrade pre/post hooks
+PRE_START_HOOKS="{{ pre_start_hooks }}"
+POST_START_HOOKS="{{ post_start_hooks }}"
+PRE_STOP_HOOKS="{{ pre_stop_hooks }}"
+POST_STOP_HOOKS="{{ post_stop_hooks }}"
+PRE_INSTALL_UPGRADE_HOOKS="{{ pre_install_upgrade_hooks }}"
+POST_INSTALL_UPGRADE_HOOKS="{{ post_install_upgrade_hooks }}"
+
 relx_usage() {
     command="$1"
 
@@ -235,6 +243,23 @@ check_replace_os_vars() {
     echo $OUT_FILE_PATH
 }
 
+relx_run_hooks() {
+    HOOKS=$1
+    for hook in $HOOKS
+    do
+        # the scripts arguments at this point are separated
+        # from each other by | , we now replace these
+        # by empty spaces and give them to the `set`
+        # command in order to be able to extract them
+        # separately
+        set `echo "$hook" | sed -e 's/|/ /g'`
+        HOOK_SCRIPT=$1; shift
+        # all hook locations are expected to be
+        # relative to the start script location
+        [ "$SCRIPT_DIR/$HOOK_SCRIPT" ] && . "$SCRIPT_DIR/$HOOK_SCRIPT" $@
+    done
+}
+
 VMARGS_PATH=$(add_path vm.args $VMARGS_PATH)
 # Extract the target node name from node.args
 NAME_ARG=$(egrep '^-s?name' "$VMARGS_PATH" || true)
@@ -330,11 +355,14 @@ case "$1" in
 
         mkdir -p "$PIPE_DIR"
 
+        relx_run_hooks "$PRE_START_HOOKS"
         "$BINDIR/run_erl" -daemon "$PIPE_DIR" "$RUNNER_LOG_DIR" \
                           "$(relx_start_command)"
+        relx_run_hooks "$POST_START_HOOKS"
         ;;
 
     stop)
+        relx_run_hooks "$PRE_STOP_HOOKS"
         # Wait for the node to completely stop...
         PID="$(relx_get_pid)"
         if ! relx_nodetool "stop"; then
@@ -344,6 +372,7 @@ case "$1" in
         do
             sleep 1
         done
+        relx_run_hooks "$POST_STOP_HOOKS"
         ;;
 
     restart)
@@ -418,8 +447,12 @@ case "$1" in
             exit 1
         fi
 
+        relx_run_hooks "$PRE_INSTALL_UPGRADE_HOOKS"
+
         exec "$BINDIR/escript" "$ROOTDIR/bin/install_upgrade.escript" \
              "$COMMAND" "{'$REL_NAME', \"$NAME_TYPE\", '$NAME', '$COOKIE'}" "$@"
+
+        relx_run_hooks "$POST_INSTALL_UPGRADE_HOOKS"
         ;;
 
     versions)

--- a/priv/templates/extended_bin
+++ b/priv/templates/extended_bin
@@ -435,8 +435,9 @@ case "$1" in
              "versions" "{'$REL_NAME', \"$NAME_TYPE\", '$NAME', '$COOKIE'}" "$@"
         ;;
 
-    console|console_clean|console_boot)
+    console|console_clean|console_boot|foreground)
         __code_paths=""
+        FOREGROUNDOPTIONS=""
         # .boot file typically just $REL_NAME (ie, the app name)
         # however, for debugging, sometimes start_clean.boot is useful.
         # For e.g. 'setup', one may even want to name another boot script.
@@ -447,6 +448,16 @@ case "$1" in
                 else
                   BOOTFILE="$REL_DIR/start"
                 fi
+                ;;
+            foreground)
+                # start up the release in the foreground for use by runit
+                # or other supervision services
+                if [ -f "$REL_DIR/$REL_NAME.boot" ]; then
+                  BOOTFILE="$REL_DIR/$REL_NAME"
+                else
+                  BOOTFILE="$REL_DIR/start"
+                fi
+                FOREGROUNDOPTIONS="-noshell -noinput +Bd"
                 ;;
             console_clean)
                 __code_paths=$(relx_get_code_paths)
@@ -470,7 +481,8 @@ case "$1" in
 
         # Build an array of arguments to pass to exec later on
         # Build it here because this command will be used for logging.
-        set -- "$BINDIR/erlexec" -boot "$BOOTFILE" -mode "$CODE_LOADING_MODE" \
+        set -- "$BINDIR/erlexec" $FOREGROUNDOPTIONS \
+            -boot "$BOOTFILE" -mode "$CODE_LOADING_MODE" \
             -boot_var ERTS_LIB_DIR "$ERTS_LIB_DIR" \
             -config "$RELX_CONFIG_PATH" \
             -args_file "$VMARGS_PATH" \
@@ -483,38 +495,6 @@ case "$1" in
         # Log the startup
         echo "$RELEASE_ROOT_DIR"
         logger -t "$REL_NAME[$$]" "Starting up"
-
-        # Start the VM
-        exec "$@" -- ${1+$ARGS}
-        ;;
-
-    foreground)
-        # start up the release in the foreground for use by runit
-        # or other supervision services
-
-        [ -f "$REL_DIR/$REL_NAME.boot" ] && BOOTFILE="$REL_NAME" || BOOTFILE=start
-        FOREGROUNDOPTIONS="-noshell -noinput +Bd"
-
-        # Setup beam-required vars
-        EMU=beam
-        PROGNAME="${0#*/}"
-
-        export EMU
-        export PROGNAME
-
-        # Store passed arguments since they will be erased by `set`
-        ARGS="$@"
-
-        # Build an array of arguments to pass to exec later on
-        # Build it here because this command will be used for logging.
-        set -- "$BINDIR/erlexec" $FOREGROUNDOPTIONS \
-            -boot "$REL_DIR/$BOOTFILE" -mode "$CODE_LOADING_MODE" -config "$RELX_CONFIG_PATH" \
-            -boot_var ERTS_LIB_DIR "$ERTS_LIB_DIR" \
-            -args_file "$VMARGS_PATH"
-
-        # Dump environment info for logging purposes
-        echo "Exec: $@" -- ${1+$ARGS}
-        echo "Root: $ROOTDIR"
 
         # Start the VM
         exec "$@" -- ${1+$ARGS}

--- a/test/rlx_test_utils.erl
+++ b/test/rlx_test_utils.erl
@@ -12,6 +12,13 @@ create_app(Dir, Name, Vsn, Deps, LibDeps) ->
     rlx_app_info:new(erlang:list_to_atom(Name), Vsn, AppDir,
                      Deps, []).
 
+create_full_app(Dir, Name, Vsn, Deps, LibDeps) ->
+    AppDir = filename:join([Dir, Name ++ "-" ++ Vsn]),
+    write_full_app_files(AppDir, Name, Vsn, Deps, LibDeps),
+    compile_src_files(AppDir),
+    rlx_app_info:new(erlang:list_to_atom(Name), Vsn, AppDir,
+                     Deps, []).
+
 create_empty_app(Dir, Name, Vsn, Deps, LibDeps) ->
     AppDir = filename:join([Dir, Name ++ "-" ++ Vsn]),
     write_app_file(AppDir, Name, Vsn, Deps, LibDeps),
@@ -49,6 +56,97 @@ get_app_metadata(Name, Vsn, Deps, LibDeps) ->
       {included_applications, LibDeps},
       {registered, []},
       {applications, Deps}]}.
+
+write_full_app_files(Dir, Name, Vsn, Deps, LibDeps) ->
+    %% write out the .app file
+    AppFilename = filename:join([Dir, "ebin", Name ++ ".app"]),
+    ok = filelib:ensure_dir(AppFilename),
+    ok = ec_file:write_term(AppFilename,
+                            get_full_app_metadata(Name, Vsn, Deps, LibDeps)),
+    %% write out the _app.erl file
+    ApplicationFilename = filename:join([Dir, "src", Name ++ "_app.erl"]),
+    ok = filelib:ensure_dir(ApplicationFilename),
+    ok = file:write_file(ApplicationFilename, full_application_contents(Name)),
+    %% write out the supervisor
+    SupervisorFilename = filename:join([Dir, "src", Name ++ "_sup.erl"]),
+    ok = filelib:ensure_dir(SupervisorFilename),
+    ok = file:write_file(SupervisorFilename, supervisor_contents(Name)),
+    %% and finally the gen_server
+    GenServerFilename = filename:join([Dir, "src", Name ++ "_srv.erl"]),
+    ok = filelib:ensure_dir(GenServerFilename),
+    ok = file:write_file(GenServerFilename, gen_server_contents(Name)),
+    ok.
+
+compile_src_files(Dir) ->
+    %% compile all *.erl files in src to ebin
+    SrcDir = filename:join([Dir, "src"]),
+    OutputDir = filename:join([Dir, "ebin"]),
+    lists:foreach(fun(SrcFile) ->
+                    {ok, _} = compile:file(SrcFile, [{outdir, OutputDir},
+                                                     return_errors])
+                  end, ec_file:find(SrcDir, "\\.erl")),
+    ok.
+
+get_full_app_metadata(Name, Vsn, Deps, LibDeps) ->
+    {application, erlang:list_to_atom(Name),
+    [{description, ""},
+     {vsn, Vsn},
+     {modules, [goal_app_app,goal_app_sup,goal_app_srv]},
+     {mod, {erlang:list_to_atom(Name ++  "_app"),
+            []}},
+     {included_applications, LibDeps},
+     {registered, []},
+     {applications, Deps}]}.
+
+full_application_contents(Name) ->
+    "-module("++Name++"_app).\n"
+    "-behaviour(application).\n"
+    "-export([start/2, stop/1]).\n"
+    "start(_StartType, _StartArgs) ->\n"
+    "   "++Name++"_sup:start_link().\n"
+    "stop(_State) ->\n"
+    "   ok.\n".
+
+supervisor_contents(Name) ->
+    "-module("++Name++"_sup).\n"
+    "-behaviour(supervisor).\n"
+    "-export([start_link/0]).\n"
+    "-export([init/1]).\n"
+    "-define(SERVER, ?MODULE).\n"
+    "start_link() ->\n"
+    "    supervisor:start_link({local, ?SERVER}, ?MODULE, []).\n"
+    "init([]) ->\n"
+    "    {ok, { {one_for_all, 0, 1},\n"
+    "            [{"++Name++"_srv, {"++Name++"_srv, start_link, []},\n"
+    "              transient, 5000, worker, ["++Name++"_srv]}\n"
+    "            ]\n"
+    "         }}.\n".
+
+gen_server_contents(Name) ->
+    "-module("++Name++"_srv).\n"
+    "-behaviour(gen_server).\n"
+    "-record(state, {}).\n"
+    "-export([start_link/0]).\n"
+    "-export([init/1,handle_call/3,handle_cast/2,\n"
+    "         handle_info/2,terminate/2,code_change/3]).\n"
+    "start_link() ->\n"
+    "    gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).\n"
+    "init([]) ->\n"
+    "    erlang:send_after(4000, self(), register_signal),"
+    "    {ok, #state{}}.\n"
+    "handle_call(_Event, _From, State) ->\n"
+    "    {reply, ok, State}.\n"
+    "handle_cast(_Event, State) ->\n"
+    "    {noreply, State}.\n"
+    "handle_info(register_signal, State) ->\n"
+    "   erlang:register(goal_app_srv_signal, spawn(fun() -> timer:sleep(200000) end)),\n"
+    "   {noreply, State};\n"
+    "handle_info(_Info, State) ->\n"
+    "    {noreply, State}.\n"
+    "terminate(_Reason, _State) ->\n"
+    "    ok.\n"
+    "code_change(_OldVsn, State, _Extra) ->\n"
+    "    {ok, State}.\n".
 
 create_random_name(Name) ->
     Name ++ erlang:integer_to_list(random_uniform(1000000)).


### PR DESCRIPTION
New 'extended_start_script_hooks' directive that allows the developer to define six different hook scripts to be invoked at pre/post start/stop/install upgrade phases.
Besides these custom defined scripts other types of builtin scripts are also available, these offer pre-packaged functionality that can be used directly, they are:

- pid - writes the beam pid to a configurable file location
              (/var/run/<rel_name>.pid by default).
- wait_for_vm_start - waits for the vm to start (ie. when it can be pinged)
- wait_for_process - waits for a configurable name to appear in the erlang process registry
The hook scripts are invoked with the 'source' command, therefore they have access to all the variables in the start script.
These hook scripts apply only to `start`, `stop` and `upgrade/downgrade/install/uninstall` commands.
The paths are relative to the start script, and the syntax is:

```
                  {extended_start_script_hooks, [
                        {pre_start, [{custom, "hooks/pre_start"}]},
                        {post_start, [{pid, "/tmp/foo.pid"},
                                      {wait_for_process, some_process},
                                      {custom, "hooks/post_start"}]},
                        {pre_stop, [{custom, "hooks/pre_stop"}]},
                        {post_stop, [{custom, "hooks/post_stop"}]}
                    ]},
```

Possible use cases:
- Cuttlefish integration, generate sys.config on the fly when starting the release
- Generate a pid to a custom location
- Feedback provider, when starting the node a post_start script can check that the entire application-specific boot process has succeeded
