### PR TITLE
Couple fixes related to vm.args and sys.config

### DIFF
--- a/src/rlx_config.erl
+++ b/src/rlx_config.erl
@@ -250,8 +250,12 @@ load_terms({release, {RelName, Vsn}, Applications, Config}, {ok, State0}) ->
             Release2 = rlx_release:config(Release1, Config),
             {ok, rlx_state:add_configured_release(State0, Release2)}
         end;
+load_terms({vm_args, false}, {ok, State}) ->
+    {ok, rlx_state:vm_args(State, false)};
 load_terms({vm_args, VmArgs}, {ok, State}) ->
     {ok, rlx_state:vm_args(State, filename:absname(VmArgs))};
+load_terms({sys_config, false}, {ok, State}) ->
+    {ok, rlx_state:sys_config(State, false)};
 load_terms({sys_config, SysConfig}, {ok, State}) ->
     {ok, rlx_state:sys_config(State, filename:absname(SysConfig))};
 load_terms({root_dir, Root}, {ok, State}) ->

--- a/src/rlx_prv_assembler.erl
+++ b/src/rlx_prv_assembler.erl
@@ -410,6 +410,8 @@ generate_start_erl_data_file(Release, ReleasesDir) ->
 copy_or_generate_vmargs_file(State, Release, RelDir) ->
     RelVmargsPath = filename:join([RelDir, "vm.args"]),
     case rlx_state:vm_args(State) of
+        false ->
+            ok;
         undefined ->
             RelName = erlang:atom_to_list(rlx_release:name(Release)),
             unless_exists_write_default(RelVmargsPath, vm_args_file(RelName));
@@ -428,6 +430,8 @@ copy_or_generate_vmargs_file(State, Release, RelDir) ->
 copy_or_generate_sys_config_file(State, RelDir) ->
     RelSysConfPath = filename:join([RelDir, "sys.config"]),
     case rlx_state:sys_config(State) of
+        false ->
+            ok;
         undefined ->
             unless_exists_write_default(RelSysConfPath, sys_config_file());
         ConfigPath ->


### PR DESCRIPTION
When using cuttlefish we don't want a sys.config or vm.args coming from relx so I've added the option to set them to `false` telling relx to not create defaults. Also fixed it so it wouldn't try to copy them to the tarfile despite not existing.