### PR TITLE
ability to pass multiple args with rpcterms

### DIFF
--- a/priv/templates/nodetool
+++ b/priv/templates/nodetool
@@ -129,7 +129,11 @@ consult(Cont, Str, Acc) ->
                     {ok, Term} = erl_parse:parse_term(Tokens),
                     consult([], Remaining, [Term | Acc]);
                 {eof, _Other} ->
-                    lists:reverse(Acc);
+                    case lists:reverse(Acc) of
+                        [] -> [];
+                        [Args | []] when is_list(Args) -> Args;
+                        [SingleArg | [] ] -> [SingleArg]
+                    end;
                 {error, Info, _} ->
                     {error, Info}
             end;


### PR DESCRIPTION
So one can invoke functions with multiple arguments by providing a list, e.g. `rpcterms io format '[ "~s:\s~p~n", ["world\sanswer", 42] ].'`  Tries to not break Mod:Fun(term) case.