### PR TITLE
Fixed template args order bug

### DIFF
--- a/src/rlx_prv_overlay.erl
+++ b/src/rlx_prv_overlay.erl
@@ -197,7 +197,9 @@ merge_overlay_vars(State, FileNames) ->
                                 %% to the current one being read
                                 OverlayRelativeRoot = filename:dirname(FileName),
                                 NewTerms = check_overlay_inclusion(State, OverlayRelativeRoot, Terms),
-                                lists:ukeymerge(1, lists:ukeysort(1, NewTerms), Acc);
+                                lists:foldl(fun(NewTerm, A) ->
+                                                lists:keystore(element(1, NewTerm), 1, A, NewTerm)
+                                            end, Acc, NewTerms);
                             {error, Reason} ->
                                 ec_cmd_log:warn(rlx_state:log(State),
                                                 format_error({unable_to_read_varsfile, FileName, Reason})),

--- a/test/rlx_release_SUITE.erl
+++ b/test/rlx_release_SUITE.erl
@@ -550,6 +550,7 @@ overlay_release(Config) ->
     VarsFile1 = filename:join([LibDir1, "vars1.config"]),
     rlx_test_utils:write_config(VarsFile1, [{yahoo, "yahoo"},
                                             {yahoo2, [{foo, "bar"}]},
+                                            {foo_yahoo, "foo_{{yahoo}}"},
                                             {foo_dir, "foodir"}]),
 
     VarsFile2 = filename:join([LibDir1, "vars2.config"]),
@@ -610,6 +611,8 @@ overlay_release(Config) ->
                  proplists:get_value(release_name, TemplateData)),
     ?assertEqual("yahoo/foo4",
                  proplists:get_value(yahoo4, TemplateData)),
+    ?assertEqual("foo_yahoo",
+                 proplists:get_value(foo_yahoo, TemplateData)),
     ?assertEqual("yahoo",
                  proplists:get_value(google, TemplateData)).
 

--- a/test/rlx_test_utils.erl
+++ b/test/rlx_test_utils.erl
@@ -77,4 +77,5 @@ test_template_contents() ->
         "{yahoo4, \"{{yahoo4}}\"}.\n"
         "{yahoo, \"{{yahoo}}\"}.\n"
         "{foo_dir, \"{{foo_dir}}\"}.\n"
+        "{foo_yahoo, \"{{foo_yahoo}}\"}.\n"
         "{google, \"{{google}}\"}.\n".


### PR DESCRIPTION
**vars.config**
```erlang
{var, "valu1"}.

{a_val, "a{{var}}"}.
{z_val, "z{{var}}"}.
```
**app.config**
```erlang
[
 {a, "{{a_val}}"},
 {z, "{{z_val}}"}
]
```
**relx.config**
```erlang
{overlay_vars, "vars.config"},
{overlay, [
    {template, "app.config", "etc/app.config"}
]}
```

You will get

**etc/app.config**
```erlang
[
 {a, "a"}, %% must be avalue1
 {z, "zvalue1"}
]
```