### PR TITLE
Use standard flags to od

### DIFF
--- a/priv/templates/extended_bin
+++ b/priv/templates/extended_bin
@@ -64,7 +64,7 @@ relx_rem_sh() {
 
 # Generate a random id
 relx_gen_id() {
-    od -X -N 4 /dev/urandom | head -n1 | awk '{print $2}'
+    od -t x -N 4 /dev/urandom | head -n1 | awk '{print $2}'
 }
 
 # Control a node


### PR DESCRIPTION
The -X flag is not supported on BusyBox for example.
Using -t x should give the same behavior as -X.