### PR TITLE
provide eval command for nodetool and start script

### DIFF
--- a/priv/templates/extended_bin
+++ b/priv/templates/extended_bin
@@ -449,9 +449,18 @@ case "$1" in
 
         relx_nodetool rpcterms $@
         ;;
+    eval)
+        # Make sure a node IS running
+        if ! relx_nodetool "ping" > /dev/null; then
+            echo "Node is not running!"
+            exit 1
+        fi
 
+        shift
+        relx_nodetool "eval" $@
+        ;;
     *)
-        echo "Usage: $REL_NAME {start|start_boot <file>|foreground|stop|restart|reboot|pid|ping|console|console_clean|console_boot <file>|attach|remote_console|upgrade|escript|rpc|rpcterms}"
+        echo "Usage: $REL_NAME {start|start_boot <file>|foreground|stop|restart|reboot|pid|ping|console|console_clean|console_boot <file>|attach|remote_console|upgrade|escript|rpc|rpcterms|eval}"
         exit 1
         ;;
 esac

--- a/priv/templates/nodetool
+++ b/priv/templates/nodetool
@@ -52,9 +52,38 @@ main(Args) ->
                 Other ->
                     io:format("~p\n", [Other])
             end;
+        ["eval" | ListOfArgs] ->
+            % shells may process args into more than one, and end up stripping
+            % spaces, so this converts all of that to a single string to parse
+            String = binary_to_list(
+                      list_to_binary(
+                        string:join(ListOfArgs," ")
+                      )
+                    ),
+
+            % then just as a convenience to users, if they forgot a trailing
+            % '.' add it for them.
+            Normalized =
+              case lists:reverse(String) of
+                [$. | _] -> String;
+                R -> lists:reverse([$. | R])
+              end,
+
+            % then scan and parse the string
+            {ok, Scanned, _} = erl_scan:string(Normalized),
+            {ok, Parsed } = erl_parse:parse_exprs(Scanned),
+
+            % and evaluate it on the remote node
+            case rpc:call(TargetNode, erl_eval, exprs, [Parsed, [] ]) of
+                {value, Value, _} ->
+                    io:format ("~p\n",[Value]);
+                {badrpc, Reason} ->
+                    io:format("RPC to ~p failed: ~p\n", [TargetNode, Reason]),
+                    halt(1)
+            end;
         Other ->
             io:format("Other: ~p\n", [Other]),
-            io:format("Usage: nodetool {ping|stop|restart|reboot|rpc|rpcterms} [RPC]\n")
+            io:format("Usage: nodetool {ping|stop|restart|reboot|rpc|rpcterms|eval [Terms]} [RPC]\n")
     end,
     net_kernel:stop().
 


### PR DESCRIPTION
While rpc and rpcterms are decent they don't quite have the functionality I would like which is executing arbitrary calls against the running node.  This adds an 'eval' command to the extended start script which calls nodetool.  With it you can do things like
```shell
% myrel eval 'node()'
'myrel@dev'
% myrel eval 'io:format("~s\n",[[<<"hello">>,$\s,"world"]]).'
hello world
ok
% bin/myrel eval 'AppVersion = fun (App) -> [ {A, V} || {A,_,V} <- application:which_applications(), A =:= App ] end, [ AppVersion (A) || A <- [kernel, myrel ]]'
[[{kernel,"2.16.4"}],[{myrel,"0.1.0"}]]
```
While these examples are contrived, you can basically use this to run arbitrary code on the running node which is useful for troubleshooting, and system inspection.