### PR TITLE
Fix renaming of .orig configuration files on Windows

### DIFF
--- a/priv/templates/bin_windows
+++ b/priv/templates/bin_windows
@@ -73,12 +73,12 @@ cd %rootdir%
 @if exist "%possible_sys%" (
   set sys_config=-config "%possible_sys%"
 )
-@if exist "%possible_sys%".orig (
-  ren "%possible_sys%".orig "%possible_sys%" 
+@if exist "%possible_sys%.orig" (
+  ren "%possible_sys%.orig" sys.config
   set sys_config=-config "%possible_sys%"
 )
-@if exist "%rel_dir%\vm.args".orig (
-  ren "%rel_dir%\vm.args" ".orig %rel_dir%\vm.args"
+@if exist "%rel_dir%\vm.args.orig" (
+  ren "%rel_dir%\vm.args.orig" vm.args
 )
 @goto :eof
 

--- a/priv/templates/extended_bin_windows
+++ b/priv/templates/extended_bin_windows
@@ -112,6 +112,13 @@
 @if exist %possible_sys% (
   set sys_config=-config "%possible_sys%"
 )
+@if exist "%possible_sys%.orig" (
+  ren "%possible_sys%.orig" sys.config
+  set sys_config=-config "%possible_sys%"
+)
+@if exist "%rel_dir%\vm.args.orig" (
+  ren "%rel_dir%\vm.args.orig" vm.args
+)
 @goto :eof
 
 :: set boot_script variable


### PR DESCRIPTION
Fix .orig rename commands in bin_windows
1. .orig was being prepended second argument rather than appended to the
   first argument
2. Windows' ren command expects the second argument to be just a file
   name (not contain drive or path components)
3. Tidy up appending of .orig, place inside double quotes rather than
   outside of quotes.

This matches the usage a few lines later:
@if exist "%rel_dir%\%rel_name%.boot" (

Copy rename commands from bin_windows to extended_bin_windows.
