### PR TITLE
Fix for #478 Boot variable $ERTS_LIB_DIR not supplied in Windows scripts

### DIFF
--- a/priv/templates/bin_windows
+++ b/priv/templates/bin_windows
@@ -34,7 +34,8 @@ cd %rootdir%
 @echo Rootdir=%converted_rootdir% >> "%erl_ini%"
 
 :: Start the release in an `erl` shell
-@"%erl%" %erl_opts% %sys_config% -boot "%boot_script%" %*
+@set boot=-boot "%boot_script%" -boot_var RELEASE_DIR "%release_root_dir%"
+@"%erl%" %erl_opts% %sys_config% %boot% %*
 
 @goto :eof
 

--- a/priv/templates/extended_bin_windows
+++ b/priv/templates/extended_bin_windows
@@ -186,7 +186,8 @@
 
 :: Start a console
 :console
-@start "%rel_name% console" %werl% -boot "%boot_script%" %sys_config%  ^
+@set boot=-boot "%boot_script%" -boot_var RELEASE_DIR "%release_root_dir%"
+@start "%rel_name% console" %werl% %boot% %sys_config%  ^
        -args_file "%vm_args%"
 @goto :eof
 
@@ -202,6 +203,7 @@
 
 :: Attach to a running node
 :attach
-@start "%node_name% attach" %werl% -boot "%clean_boot_script%" ^
+@set boot=-boot "%clean_boot_script%" -boot_var RELEASE_DIR "%release_root_dir%"
+@start "%node_name% attach" %werl% %boot% ^
        -remsh %node_name% %node_type% console -setcookie %cookie%
 @goto :eof


### PR DESCRIPTION
Proposed fix for #478. To test this fix, the following issues / pull requests need to be resolved first: #464 #467 #470 #471.

Add missing -boot_var argument to Windows scripts when starting erlang.

Use different boot variables on Windows vs non-Windows.

The built-in $ROOT boot variable points to the erts directory on Windows
(dictated by erl.ini [erlang] Rootdir=) and so a boot variable $RELEASE_DIR
is made pointing to the release directory instead of the $ERTS_LIB_DIR boot variable.