### PR TITLE
Use erl script to generate id

### DIFF
--- a/priv/templates/extended_bin
+++ b/priv/templates/extended_bin
@@ -64,7 +64,7 @@ relx_rem_sh() {
 
 # Generate a random id
 relx_gen_id() {
-    od -t x -N 4 /dev/urandom | head -n1 | awk '{print $2}'
+    erl -noshell -eval 'io:format("~.16b~n", [random:uniform(255*255*255*255)]), halt(0).'
 }
 
 # Control a node


### PR DESCRIPTION
relx_gen_id function uses od whose options can differ from a shell to another (-t x / -X ...)
This patch updates the relx_gen_id function to use erlang script, which is more portable.