### PR TITLE
Nicer templates

### DIFF
--- a/priv/templates/extended_bin
+++ b/priv/templates/extended_bin
@@ -2,6 +2,8 @@
 
 set -e
 
+export RUN_ERL_DISABLE_FLOWCNTRL=true
+
 SCRIPT=$(readlink $0 || true)
 if [ -z $SCRIPT ]; then
     SCRIPT=$0

--- a/priv/templates/extended_bin
+++ b/priv/templates/extended_bin
@@ -4,6 +4,10 @@ set -e
 
 export RUN_ERL_DISABLE_FLOWCNTRL=true
 
+if [ "$TERM" = "dumb" -o -z "$TERM" ]; then
+  export TERM=screen
+fi
+
 SCRIPT=$(readlink $0 || true)
 if [ -z $SCRIPT ]; then
     SCRIPT=$0

--- a/priv/templates/vm_args
+++ b/priv/templates/vm_args
@@ -17,3 +17,9 @@
 
 ## Tweak GC to run more often
 ##-env ERL_FULLSWEEP_AFTER 10
+
+# Disable the emulator break handler
+# it easy to accidentally type ctrl-c when trying
+# to reach for ctrl-d. ctrl-c on a live node can
+# have very undesirable results
+#+Bi


### PR DESCRIPTION
We run erlang in production and have noticed that it is quite easy to shoot yourself in the foot when accidentally typing ctrl-c or ctrl-s. Both of these shortcuts are easy to type if you are reaching for ctrl-a, ctrl-d or ctrl-r. ctrl-c by default will run the erlang emulator break handler that will pause the node. This can be destructive on a live system. ctrl-s will cause erlang to block flow control which has some very undesirable effects (see here: http://erlang.org/pipermail/erlang-patches/2010-March/000883.html)

The option to disable the break handler is commented out the vm_args file but you might want to make it the default.

I've also included a change to the script that will set the TERM variable to something sane. For example when deploying from capistrano this will be set to 'dumb' I think which causes problems when you attach to the node. However, it might be better to just hardcode TERM to a particular value. I'm not sure.