### PR TITLE
Handle release_handler old_processes error when doing a soft purge relup

### DIFF
--- a/priv/templates/install_upgrade_escript
+++ b/priv/templates/install_upgrade_escript
@@ -92,7 +92,18 @@ install_and_permafy(TargetNode, RelName, Vsn) ->
                     [io_lib:format("* ~s\t~s~n",[V,S]) ||  {V,S} <- which_releases(TargetNode)]),
             ?INFO("Installed versions:~n~s", [VerList]),
             ?INFO("ERROR: Unable to revert to '~s' - not installed.~n", [Vsn]),
-            erlang:halt(2)
+            erlang:halt(2);
+        %% as described in http://erlang.org/doc/man/appup.html, when performing a relup
+        %% with soft purge:
+        %%      If the value is soft_purge, release_handler:install_release/1
+        %%      returns {error,{old_processes,Mod}}
+        {error, {old_processes, Mod}} ->
+            ?INFO("ERROR: unable to install '~s' - old processes still running code from module ~p~n",
+                [Vsn, Mod]),
+            erlang:halt(3);
+        {error, Reason1} ->
+            ?INFO("ERROR: release_handler:install_release failed: ~p~n",[Reason1]),
+            erlang:halt(4)
     end.
 
 permafy(TargetNode, RelName, Vsn) ->


### PR DESCRIPTION
As described in http://erlang.org/doc/man/appup.html, when performing a relup
with soft purge:
      If the value is soft_purge, release_handler:install_release/1
      returns {error,{old_processes,Mod}}

Currently it fails with:
 `escript: exception error: no case clause matching {error,{old_processes,relapp_m1}}`
