### PR TITLE
Always ask release handler to update paths on relup

### DIFF
--- a/priv/templates/install_upgrade_escript
+++ b/priv/templates/install_upgrade_escript
@@ -81,7 +81,8 @@ install_and_permafy(TargetNode, RelName, Vsn) ->
             ?INFO("ERROR: release_handler:check_install_release failed: ~p~n",[Reason]),
             erlang:halt(3)
     end,
-    case rpc:call(TargetNode, release_handler, install_release, [Vsn], ?TIMEOUT) of
+    case rpc:call(TargetNode, release_handler, install_release,
+                  [Vsn, [{update_paths, true}]], ?TIMEOUT) of
         {ok, _, _} ->
             ?INFO("Installed Release: ~s~n", [Vsn]),
             permafy(TargetNode, RelName, Vsn),


### PR DESCRIPTION
When performing a relup that involves starting a new
application we need to inform release handler that the
code paths need to be updated to account for the new apps,
otherwise the relup instruction application:start/2 will fail
since it is unable to find the .app file.