### PR TITLE
Add -heart option to activate heart monitoring process

### DIFF
--- a/priv/templates/extended_bin
+++ b/priv/templates/extended_bin
@@ -376,7 +376,7 @@ case "$1" in
 
         # Build an array of arguments to pass to exec later on
         # Build it here because this command will be used for logging.
-        set -- "$BINDIR/erlexec" -boot "$BOOTFILE" -mode "$CODE_LOADING_MODE" \
+        set -- "$BINDIR/erlexec" -heart -boot "$BOOTFILE" -mode "$CODE_LOADING_MODE" \
             -boot_var ERTS_LIB_DIR "$ERTS_LIB_DIR" \
             -config "$RELX_CONFIG_PATH" \
             -args_file "$VMARGS_PATH"


### PR DESCRIPTION
Heart variables are prepared at "start)" case, but they have no effect because "-heart" is not used,
after this update, release is automatically restarted on crash and additional "heart" process appear