### PR TITLE
Don't include nodetool when include_nodetool is false

### DIFF
--- a/src/rlx_prv_assembler.erl
+++ b/src/rlx_prv_assembler.erl
@@ -337,25 +337,21 @@ write_bin_file(State, Release, OutputDir, RelDir) ->
     ErlOpts = rlx_state:get(State, erl_opts, ""),
     {OsFamily, _OsName} = os:type(),
 
+    case rlx_state:get(State, include_nodetool, false) of
+        true ->
+            include_nodetool(BinDir);
+        false ->
+            ok
+    end,
     StartFile = case rlx_state:get(State, extended_start_script, false) of
                     false ->
-                        case rlx_state:get(State, include_nodetool, false) of
-                            true ->
-                                include_nodetool(BinDir);
-                            false ->
-                                ok
-                        end,
                         bin_file_contents(OsFamily, RelName, RelVsn,
                                           rlx_release:erts(Release),
                                           ErlOpts);
                     true ->
-                        case rlx_state:get(State, extended_start_script, false) of
-                            true ->
-                                include_nodetool(BinDir);
-                            false ->
-                                ok
-                        end,
-                        extended_bin_file_contents(OsFamily, RelName, RelVsn, rlx_release:erts(Release), ErlOpts)
+                        extended_bin_file_contents(OsFamily, RelName, RelVsn,
+                                                   rlx_release:erts(Release),
+                                                   ErlOpts)
                 end,
     %% We generate the start script by default, unless the user
     %% tells us not too


### PR DESCRIPTION
With extended_start_script=true, nodetool and install_upgrade.escript
were included independent of include_nodetool.