### PR TITLE
Feature/replace os vars test

### DIFF
--- a/priv/templates/bin_windows
+++ b/priv/templates/bin_windows
@@ -74,13 +74,6 @@ cd %rootdir%
 @if exist "%possible_sys%" (
   set sys_config=-config "%possible_sys%"
 )
-@if exist "%possible_sys%".orig (
-  ren "%possible_sys%".orig "%possible_sys%" 
-  set sys_config=-config "%possible_sys%"
-)
-@if exist "%rel_dir%\vm.args".orig (
-  ren "%rel_dir%\vm.args" ".orig %rel_dir%\vm.args"
-)
 @goto :eof
 
 :: set boot_script variable

--- a/priv/templates/extended_bin
+++ b/priv/templates/extended_bin
@@ -98,28 +98,6 @@ if [ -z "$VMARGS_PATH" ]; then
     fi
 fi
 
-orig_vmargs_path="$VMARGS_PATH.orig"
-if [ $RELX_REPLACE_OS_VARS ]; then
-    #Make sure we don't break dev mode by keeping the symbolic link to 
-    #the user's vm.args
-    if [ ! -L "$orig_vmargs_path" ]; then
-       #we're in copy mode, rename the vm.args file to vm.args.orig
-       mv "$VMARGS_PATH" "$orig_vmargs_path"
-    fi
-
-    awk '{while(match($0,"[$]{[^}]*}")) {var=substr($0,RSTART+2,RLENGTH -3);gsub("[$]{"var"}",ENVIRON[var])}}1' < "$orig_vmargs_path" > "$VMARGS_PATH"
- else
-    #We don't need to replace env. vars, just rename the
-    #symlink vm.args.orig to vm.args, and keep it as a
-    #symlink.
-    if [ -L "$orig_vmargs_path" ]; then
-       mv "$orig_vmargs_path" "$VMARGS_PATH" 
-    fi
-fi
-
-# Make sure log directory exists
-mkdir -p "$RUNNER_LOG_DIR"
-
 # Use $CWD/sys.config if exists, otherwise releases/VSN/sys.config
 if [ -z "$RELX_CONFIG_PATH" ]; then
     if [ -f "$RELEASE_ROOT_DIR/sys.config" ]; then
@@ -129,24 +107,48 @@ if [ -z "$RELX_CONFIG_PATH" ]; then
     fi
 fi
 
+orig_vmargs_path="$VMARGS_PATH.orig"
+if [ $RELX_REPLACE_OS_VARS ]; then
+    # if there is no vm.args.orig then make a copy of the
+    # the original vm.args
+    if [ ! -f "$orig_vmargs_path" ]; then
+       mv "$VMARGS_PATH" "$orig_vmargs_path"
+    fi
+
+    # apply the environment variable substitution to vm.args.orig
+    # the result is saved to vm.args
+    awk '{while(match($0,"[$]{[^}]*}")) {var=substr($0,RSTART+2,RLENGTH -3);gsub("[$]{"var"}",ENVIRON[var])}}1' < "$orig_vmargs_path" > "$VMARGS_PATH"
+else
+    # if a vm.args.orig is present this means that
+    # env variable substitution has occurred before
+    # so use the original
+    if [ -f "$orig_vmargs_path" ]; then
+       mv "$orig_vmargs_path" "$VMARGS_PATH"
+    fi
+fi
+
 orig_relx_config_path="$RELX_CONFIG_PATH.orig"
 if [ $RELX_REPLACE_OS_VARS ]; then
-    #Make sure we don't break dev mode by keeping the symbolic link to 
-    #the user's sys.config
-    if [ ! -L "$orig_relx_config_path" ]; then
-       #We're in copy mode, rename sys.config to sys.config.orig
+    # if there is no sys.config.orig then make a copy of the
+    # the original sys.config
+    if [ ! -f "$orig_relx_config_path" ]; then
        mv "$RELX_CONFIG_PATH" "$orig_relx_config_path"
     fi
 
+    # apply the environment variable substitution to sys.config.orig
+    # the result is saved to sys.config
     awk '{while(match($0,"[$]{[^}]*}")) {var=substr($0,RSTART+2,RLENGTH -3);gsub("[$]{"var"}",ENVIRON[var])}}1' < "$orig_relx_config_path" > "$RELX_CONFIG_PATH"
- else
-    #We don't need to replace env. vars, just rename the
-    #symlink sys.config.orig to sys.config. Keep it as 
-    #a symlink.
-    if [ -L "$orig_relx_config_path" ]; then
-       mv "$orig_relx_config_path"  "$RELX_CONFIG_PATH"
+else
+    # if a sys.config.orig is present this means that
+    # env variable substitution has occurred before
+    # so use the original
+    if [ -f "$orig_relx_config_path" ]; then
+       mv "$orig_relx_config_path" "$RELX_CONFIG_PATH"
     fi
 fi
+
+# Make sure log directory exists
+mkdir -p "$RUNNER_LOG_DIR"
 
 # Extract the target node name from node.args
 NAME_ARG=$(egrep '^-s?name' "$VMARGS_PATH" || true)

--- a/src/rlx_prv_assembler.erl
+++ b/src/rlx_prv_assembler.erl
@@ -453,7 +453,7 @@ copy_or_symlink_config_file(State, ConfigPath, RelConfPath) ->
     ensure_not_exist(RelConfPath),
     case rlx_state:dev_mode(State) of
         true ->
-            ok = rlx_util:symlink_or_copy(ConfigPath, RelConfPath ++ ".orig");
+            ok = rlx_util:symlink_or_copy(ConfigPath, RelConfPath);
         _ ->
             ok = ec_file:copy(ConfigPath, RelConfPath)
     end.

--- a/src/rlx_prv_overlay.erl
+++ b/src/rlx_prv_overlay.erl
@@ -461,6 +461,14 @@ write_template(OverlayVars, FromFile, ToFile) ->
                 {ok, IoData} ->
                     case filelib:ensure_dir(ToFile) of
                         ok ->
+                            %% we were asked to render a template
+                            %% onto a symlink, this would cause an overwrite
+                            %% of the original file, so we delete the symlink
+                            %% and go ahead with the template render
+                            case ec_file:is_symlink(ToFile) of
+                                true -> ec_file:remove(ToFile);
+                                false -> ok
+                            end,
                             case file:write_file(ToFile, IoData) of
                                 ok ->
                                     {ok, FileInfo} = file:read_file_info(FromFile),


### PR DESCRIPTION
The first run would correctly replace the environment variables, however it would also overwrite the original vm.args and sys.config thus preventing any further substitution in subsequent runs. Dev mode runs were also broken, all runs after the first were required to also define the RELX_REPLACE_OS_VARS variable in order not to overwrite the current vm.args with the original one,
this prevented simply attaching to an already running node that was started this way.

This involved reverting part of #441 mostly to simplify the logic
which is now: sys.config and vm.args are created both in dev and normal mode, if os vars replace is requested then a copy of these files is made once and kept in sys.config.orig and vm.args.orig, subsequent runs use these original files to continue performing the variable substitution. If a run is made without the RELX_REPLACE_OS_VARS set any existent .orig files are renamed to their original names.