### PR TITLE
Bash vars

### DIFF
--- a/priv/templates/extended_bin
+++ b/priv/templates/extended_bin
@@ -198,12 +198,13 @@ make_out_file_path() {
 
 # Replace environment variables
 replace_os_vars() {
-    if [ -n "$BASH" ]; then
+    if [ -n "${BASH_VERSION}" ]; then
         awk '{
             while(match($0,/\$[{(][^{}()]+?[})]/)) {
                 s=RSTART; n=RLENGTH;
                 v0=substr($0,0,s-1); v1=substr($0,s,n); v2=substr($0,n+s,length($0)-s-n+1)
-                "echo "v1|getline v; $0=sprintf("%s%s%s", v0, v, v2)
+                vv=sprintf("/bin/bash -c \"/bin/echo %s\"", v1)
+                vv|getline v; $0=sprintf("%s %s%s", v0, v, v2)
             }
         }1' < "$1" > "$2"
     else

--- a/priv/templates/extended_bin
+++ b/priv/templates/extended_bin
@@ -198,12 +198,22 @@ make_out_file_path() {
 
 # Replace environment variables
 replace_os_vars() {
-    awk '{
-        while(match($0,"[$]{[^}]*}")) {
-            var=substr($0,RSTART+2,RLENGTH -3)
-            gsub("[$]{"var"}",ENVIRON[var])
-        }
-    }1' < "$1" > "$2"
+    if [ -n "$BASH" ]; then
+        awk '{
+            while(match($0,/\$[{(][^{}()]+?[})]/)) {
+                s=RSTART; n=RLENGTH;
+                v0=substr($0,0,s-1); v1=substr($0,s,n); v2=substr($0,n+s,length($0)-s-n+1)
+                "echo "v1|getline v; $0=sprintf("%s%s%s", v0, v, v2)
+            }
+        }1' < "$1" > "$2"
+    else
+        awk '{
+            while(match($0,"[$]{[^}]*}")) {
+                var=substr($0,RSTART+2,RLENGTH -3)
+                gsub("[$]{"var"}",ENVIRON[var])
+            }
+        }1' < "$1" > "$2"
+    fi
 }
 
 add_path() {


### PR DESCRIPTION
Extend support for advanced variable replacement in bash

This update extends PR #427 by supporting variable replacement
syntax of bash to be used in vm.args and sys.config. If the current
shell is `bash`, then variables can contain things like `${NAME,,}`, `${NAME^^}`,
`${NAME:-${DEF_NAME}}`, etc.

The changes are backward-compatible with non-bash shells.
