### PR TITLE
append the user name to the pipe dirname

### DIFF
--- a/priv/templates/extended_bin
+++ b/priv/templates/extended_bin
@@ -29,7 +29,6 @@ CODE_LOADING_MODE="${CODE_LOADING_MODE:-embedded}"
 REL_DIR="$RELEASE_ROOT_DIR/releases/$REL_VSN"
 ERL_OPTS="{{ erl_opts }}"
 RUNNER_LOG_DIR="${RUNNER_LOG_DIR:-$RELEASE_ROOT_DIR/log}"
-PIPE_NAME="${PIPE_NAME:-$USER}"
 
 relx_usage() {
     command="$1"
@@ -268,7 +267,7 @@ RELX_CONFIG_PATH=$(check_replace_os_vars sys.config $RELX_CONFIG_PATH)
 # Make sure log directory exists
 mkdir -p "$RUNNER_LOG_DIR"
 
-PIPE_DIR="${PIPE_DIR:-/tmp/$PIPE_NAME/$NAME/}"
+PIPE_DIR="${PIPE_DIR:-/tmp/erl_pipes/$NAME/}"
 
 # Extract the target cookie
 COOKIE_ARG="$(grep '^-setcookie' "$VMARGS_PATH" || true)"
@@ -329,10 +328,14 @@ case "$1" in
         HEART_COMMAND="$RELEASE_ROOT_DIR/bin/$REL_NAME $CMD"
         export HEART_COMMAND
 
-        mkdir -p "$PIPE_DIR"
+        if mkdir -p "$PIPE_DIR" ; then
 
-        "$BINDIR/run_erl" -daemon "$PIPE_DIR" "$RUNNER_LOG_DIR" \
-                          "$(relx_start_command)"
+            "$BINDIR/run_erl" -daemon "$PIPE_DIR" "$RUNNER_LOG_DIR" \
+                              "$(relx_start_command)"
+        else
+            echo "create dir $PIPE_DIR failed, aborted"
+            exit 1
+        fi
         ;;
 
     stop)

--- a/priv/templates/extended_bin
+++ b/priv/templates/extended_bin
@@ -267,7 +267,7 @@ RELX_CONFIG_PATH=$(check_replace_os_vars sys.config $RELX_CONFIG_PATH)
 # Make sure log directory exists
 mkdir -p "$RUNNER_LOG_DIR"
 
-PIPE_DIR="${PIPE_DIR:-/tmp/erl_pipes/$NAME/}"
+PIPE_DIR="${PIPE_DIR:-/tmp/erl_pipes_$USER/$NAME/}"
 
 # Extract the target cookie
 COOKIE_ARG="$(grep '^-setcookie' "$VMARGS_PATH" || true)"

--- a/priv/templates/extended_bin
+++ b/priv/templates/extended_bin
@@ -29,6 +29,7 @@ CODE_LOADING_MODE="${CODE_LOADING_MODE:-embedded}"
 REL_DIR="$RELEASE_ROOT_DIR/releases/$REL_VSN"
 ERL_OPTS="{{ erl_opts }}"
 RUNNER_LOG_DIR="${RUNNER_LOG_DIR:-$RELEASE_ROOT_DIR/log}"
+PIPE_NAME="${PIPE_NAME:-$USER}"
 
 relx_usage() {
     command="$1"
@@ -267,7 +268,7 @@ RELX_CONFIG_PATH=$(check_replace_os_vars sys.config $RELX_CONFIG_PATH)
 # Make sure log directory exists
 mkdir -p "$RUNNER_LOG_DIR"
 
-PIPE_DIR="${PIPE_DIR:-/tmp/erl_pipes_$USER/$NAME/}"
+PIPE_DIR="${PIPE_DIR:-/tmp/$PIPE_NAME/$NAME/}"
 
 # Extract the target cookie
 COOKIE_ARG="$(grep '^-setcookie' "$VMARGS_PATH" || true)"


### PR DESCRIPTION
In some cases, the first time, the root user run the command, and create the pipe dir in the /tmp directory.
And then, the other user can not run the command any more and fail sliently, without any error report.
It is because the other user can not recreate the dir as the root has created it.
To avoid this, just append the user name append the pipe dirname, and every user creates their own pipe dirs themselves.