### PR TITLE
Only use multi-node sys.config if requested when replacing OS vars

### DIFF
--- a/priv/templates/extended_bin
+++ b/priv/templates/extended_bin
@@ -193,7 +193,11 @@ make_out_file_path() {
 
     PFX=$(echo $IN   | awk '{sub(/\.[^.]+$/, "", $0)}1')
     SFX=$(echo $FILE | awk -F . '{if (NF>1) print $NF}')
-    echo "${PFX}.${NAME}.${SFX}"
+    if [ $RELX_MULTI_NODE ]; then
+        echo "${PFX}.${NAME}.${SFX}"
+    else
+        echo "${PFX}.${SFX}"
+    fi
 }
 
 # Replace environment variables
@@ -233,11 +237,18 @@ check_replace_os_vars() {
 
         # apply the environment variable substitution to $IN_FILE_PATH
         # the result is saved to $OUT_FILE_PATH
-        replace_os_vars "$IN_FILE_PATH" "$OUT_FILE_PATH"
+        # if they are both the same, then ensure that we don't clobber
+        # the file by saving a backup with the .orig extension
+        if [ "$IN_FILE_PATH" = "$OUT_FILE_PATH" ]; then
+            cp "$IN_FILE_PATH" "$ORIG_FILE_PATH"
+            replace_os_vars "$ORIG_FILE_PATH" "$OUT_FILE_PATH"
+        else
+            replace_os_vars "$IN_FILE_PATH" "$OUT_FILE_PATH"
+        fi
     else
         # If vm.arg.orig or sys.config.orig is present then use that
         if [ -f "$ORIG_FILE_PATH" ]; then
-           OUT_FILE_PATH="$ORIG_FILE_PATH"
+           cp "$ORIG_FILE_PATH" "$OUT_FILE_PATH"
         fi
     fi
     echo $OUT_FILE_PATH


### PR DESCRIPTION
When replacing OS vars only create multi-node sys.config
files (ie. filenames containing the node name) only if explicitly
requested. This is necessary because inclusion of other config
files inside of sys.config is only allowed if the file is actually called
sys.config and nothing else.