### PR TITLE
Don't rewrite app files if contents are the same

### DIFF
--- a/src/rlx_prv_assembler.erl
+++ b/src/rlx_prv_assembler.erl
@@ -121,7 +121,10 @@ format_error({start_clean_script_generation_error, Module, Errors}) ->
      rlx_util:indent(2), Module:format_error(Errors)];
 format_error({strip_release, Reason}) ->
     io_lib:format("Stripping debug info from release beam files failed becuase ~s",
-                  [beam_lib:format_error(Reason)]).
+                  [beam_lib:format_error(Reason)]);
+format_error({rewrite_app_file, AppFile, Error}) ->
+    io_lib:format("Unable to rewrite .app file ~s due to ~p",
+                  [AppFile, Error]).
 
 %%%===================================================================
 %%% Internal Functions
@@ -255,13 +258,16 @@ rewrite_app_file(State, App, TargetDir) ->
                                  ,AppData2
                                  ,{modules, OldModules -- ExcludedModules})
         end,
-    Spec = io_lib:format("~p.\n", [{application, AppName, AppData3}]),
-    write_file_if_contents_differ(AppFile, Spec).
+    Spec = [{application, AppName, AppData3}],
+    case write_file_if_contents_differ(AppFile, Spec) of
+        ok -> ok;
+        Error -> ?RLX_ERROR({rewrite_app_file, AppFile, Error})
+    end.
 
-write_file_if_contents_differ(Filename, Bytes) ->
-    ToWrite = iolist_to_binary(Bytes),
-    case file:read_file(Filename) of
-        {ok, ToWrite} ->
+write_file_if_contents_differ(Filename, Spec) ->
+    ToWrite = io_lib:format("~p.\n", Spec),
+    case file:consult(Filename) of
+        {ok, Spec} ->
             ok;
         {ok,  _} ->
             file:write_file(Filename, ToWrite);


### PR DESCRIPTION
When comparing .app files to check if a rewrite is
necessary do so by comparing erlang terms instead
of bytes, the original .app might contain comments
for example and cause unnecessary rewrites.
This proves a problem when dealing with erts .app
files that might be read-only at the origin and
thus cause a failed release on relx that is 
uncalled for since there might have been no changes
at all.

This fixes #564 and erlang/rebar3#1441