### PR TITLE
Ensure stdlib,kernel as application dependencies

### DIFF
--- a/src/rlx_app_discovery.erl
+++ b/src/rlx_app_discovery.erl
@@ -293,9 +293,19 @@ get_vsn(AppDir, AppName, AppDetail) ->
 -spec get_deps(binary(), atom(), string(), proplists:proplist()) ->
                       {ok, rlx_app_info:t()} | {error, Reason::term()}.
 get_deps(AppDir, AppName, AppVsn, AppDetail) ->
-    ActiveApps = proplists:get_value(applications, AppDetail, []),
+    %% ensure that at least stdlib and kernel are defined as application deps
+    ActiveApps = ensure_stdlib_kernel(AppName,
+                                      proplists:get_value(applications, AppDetail, [])),
     LibraryApps = proplists:get_value(included_applications, AppDetail, []),
     rlx_app_info:new(AppName, AppVsn, AppDir, ActiveApps, LibraryApps).
+
+-spec ensure_stdlib_kernel(AppName :: atom(),
+                           Apps :: list(atom())) -> list(atom()).
+ensure_stdlib_kernel(kernel, Deps) -> Deps;
+ensure_stdlib_kernel(stdlib, Deps) -> Deps;
+ensure_stdlib_kernel(_AppName, Deps) ->
+    %% ensure that stdlib and kernel are the first deps
+    [kernel, stdlib | Deps -- [stdlib, kernel]].
 
 %%%===================================================================
 %%% Test Functions

--- a/test/rlx_release_SUITE.erl
+++ b/test/rlx_release_SUITE.erl
@@ -1436,7 +1436,7 @@ make_exclude_modules_release(Config) ->
                          {modules,[]},
                          {included_applications,[]},
                          {registered,[]},
-                         {applications,[stdlib,kernel]}]}]},
+                         {applications,[kernel,stdlib]}]}]},
                  file:consult(filename:join([OutputDir, "foo", "lib",
                                              "non_goal_1-0.0.1", "ebin",
                                              "non_goal_1.app"]))).


### PR DESCRIPTION
Make this dependency explicit as it was causing
apps with empty application lists to not be included
in the generated release.

Fixes #434, #566 