### PR TITLE
add osx configuration to .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,29 @@
 language: erlang
-sudo: required
-otp_release:
-  - 19.1
-  - 18.3
-  - 17.0
-  - R16B03-1
-  - R15B03
+matrix:
+  include:
+    - os: linux
+      sudo: required
+      otp_release: R15B03
+    - os: linux
+      sudo: required
+      otp_release: R16B03-1
+    - os: linux
+      sudo: required
+      otp_release: 17.5
+    - os: linux
+      sudo: required
+      otp_release: 18.3
+    - os: linux
+      sudo: required
+      otp_release: 19.2
+    - os: osx
+      sudo: required
+      language: generic
 before_script:
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
+  ## should eventually use a tap that has previous erlang versions here
+  ## as this only uses the latest erlang available via brew
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install erlang; fi
   - wget https://s3.amazonaws.com/rebar3/rebar3
   - chmod +x rebar3
 script: "./rebar3 update && ./rebar3 ct"


### PR DESCRIPTION
rebar3's release provider (which uses relx) is currently broken on osx and i suspect relx is also broken on osx