### PR TITLE
Drop use of export_all erlc directive

### DIFF
--- a/src/rlx_goal.erl
+++ b/src/rlx_goal.erl
@@ -10,8 +10,6 @@
 -define(p_seq,true).
 -define(p_string,true).
 
-
--compile(export_all).
 -spec file(file:name()) -> any().
 file(Filename) -> case file:read_file(Filename) of {ok,Bin} -> parse(Bin); Err -> Err end.
 


### PR DESCRIPTION
Starting from OTP20 this will trigger a warning, since we
use the warnings_as_errors the build would fail when using
this OTP release onwards.

Addresses #573 