### PR TITLE
Don't drop debug info on default build

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Building
 To build relx and generate a standalone escript executable:
 
     $ ./rebar3 update
-    $ ./rebar3 escriptize
+    $ ./rebar3 as escript escriptize
 
 This creates the executable `_build/default/bin/relx`.
 

--- a/bootstrap.cmd
+++ b/bootstrap.cmd
@@ -3,7 +3,7 @@
 
 :: Get dependencies, compile and escriptize relx
 @cmd /c @rebar3 update
-@cmd /c @rebar3 escriptize
+@cmd /c @rebar3 as escript escriptize
 
 :: Create a shortcut file for running the relx command
 @set relx_cmd=relx.cmd

--- a/rebar.config
+++ b/rebar.config
@@ -17,7 +17,6 @@
     [{platform_define, "^[0-9]+", namespaced_types},
      {platform_define, "^1[8|9]", rand_module},
      {platform_define, "^2", rand_module},
-     no_debug_info,
      warnings_as_errors,
      inline]}.
 
@@ -39,7 +38,15 @@
                                     {add, getopt, [{erl_opts, [debug_info]}]},
                                     {add, bbmustache, [{erl_opts, [debug_info]}]},
                                     {add, cf, [{erl_opts, [debug_info]}]}]},
-                       {erl_opts, [debug_info]}]}
+                       {erl_opts, [debug_info]}]},
+            {escript, [
+                {overrides, [{add, erlware_commons, [{erl_opts, [no_debug_info]}]},
+                             {add, providers, [{erl_opts, [no_debug_info]}]},
+                             {add, getopt, [{erl_opts, [no_debug_info]}]},
+                             {add, bbmustache, [{erl_opts, [no_debug_info]}]},
+                             {add, cf, [{erl_opts, [no_debug_info]}]}]},
+                {erl_opts, [no_debug_info]}
+            ]}
            ]}.
 
 {overrides, [{override, erlware_commons, [


### PR DESCRIPTION
Drop it only when generating relx escript.