### PR TITLE
Only ensure kernel,stdlib for empty dep apps

### DIFF
--- a/src/rlx_app_discovery.erl
+++ b/src/rlx_app_discovery.erl
@@ -303,9 +303,10 @@ get_deps(AppDir, AppName, AppVsn, AppDetail) ->
                            Apps :: list(atom())) -> list(atom()).
 ensure_stdlib_kernel(kernel, Deps) -> Deps;
 ensure_stdlib_kernel(stdlib, Deps) -> Deps;
-ensure_stdlib_kernel(_AppName, Deps) ->
-    %% ensure that stdlib and kernel are the first deps
-    [kernel, stdlib | Deps -- [stdlib, kernel]].
+ensure_stdlib_kernel(_AppName, []) ->
+    %% minimum required deps are kernel and stdlib
+    [kernel, stdlib];
+ensure_stdlib_kernel(_AppName, Deps) -> Deps.
 
 %%%===================================================================
 %%% Test Functions

--- a/test/rlx_release_SUITE.erl
+++ b/test/rlx_release_SUITE.erl
@@ -1436,7 +1436,7 @@ make_exclude_modules_release(Config) ->
                          {modules,[]},
                          {included_applications,[]},
                          {registered,[]},
-                         {applications,[kernel,stdlib]}]}]},
+                         {applications,[stdlib,kernel]}]}]},
                  file:consult(filename:join([OutputDir, "foo", "lib",
                                              "non_goal_1-0.0.1", "ebin",
                                              "non_goal_1.app"]))).


### PR DESCRIPTION
Do not try and ensure them for every app, there
are some OTP apps that only require kernel and
there's really no point in rewriting those.