### PR TITLE
Only print lines for os var that are set

### DIFF
--- a/priv/templates/extended_bin
+++ b/priv/templates/extended_bin
@@ -229,7 +229,8 @@ replace_os_vars() {
     awk '{
         while(match($0,"[$]{[^}]*}")) {
             var=substr($0,RSTART+2,RLENGTH -3)
-            gsub("[$]{"var"}",ENVIRON[var])
+            if (ENVIRON[var]) gsub("[$]{"var"}",ENVIRON[var]);
+            else next
         }
     }1' < "$1" > "$2"
 }


### PR DESCRIPTION
Would prefer just using bash echo eval trick, which would allow specifying default etc, but this atleast allows setting the default in application env and optionally configuring if ENV var are set.