### PR TITLE
Windows bat file has an error, causing upgrade to not work

### DIFF
--- a/priv/templates/extended_bin_windows
+++ b/priv/templates/extended_bin_windows
@@ -180,7 +180,7 @@ set description=Erlang node %node_name% in %rootdir%
   set ERRORLEVEL=1
   exit /b %ERRORLEVEL%
 )
-@%escript% "%rootdir%/bin/install_upgrade.escript" "%rel_name%" "%node_name%" "%cookie%" "%2"
+@%escript% "%rootdir%/bin/install_upgrade.escript" "install" "%rel_name%" "%node_name%" "%cookie%" "%2"
 @goto :eof
 
 :: Start a console


### PR DESCRIPTION
when calling the new install_upgrade.escript, the first parameter needs to be 'install' or 'unpack'

