### PR TITLE
Rename gb_tree:tree to gb_trees:tree

### DIFF
--- a/src/rlx_depsolver.erl
+++ b/src/rlx_depsolver.erl
@@ -113,7 +113,7 @@
 %% type
 %%============================================================================
 -ifdef(namespaced_types).
--type dep_graph() :: gb_tree:tree().
+-type dep_graph() :: gb_trees:tree().
 -else.
 -type dep_graph() :: gb_tree().
 -endif.


### PR DESCRIPTION
Type `gb_tree:tree()` does not exist and it seems that this line causes a warning when I use dialyzer (dialyxir, actually). I guess `gb_trees:tree()` is correct.