### PR TITLE
Prevent .erlang from prepending string to the erl root dir

### DIFF
--- a/priv/templates/bin
+++ b/priv/templates/bin
@@ -22,7 +22,7 @@ find_erts_dir() {
     else
         __erl="$(which erl)"
         code="io:format(\"~s\", [code:root_dir()]), halt()."
-        __erl_root="$("$__erl" -noshell -eval "$code")"
+        __erl_root="$("$__erl" -boot no_dot_erlang -noshell -eval "$code")"
         ERTS_DIR="$__erl_root/erts-$ERTS_VSN"
         ROOTDIR="$__erl_root"
     fi

--- a/priv/templates/bin_windows
+++ b/priv/templates/bin_windows
@@ -60,7 +60,7 @@ cd %rootdir%
 @for /f "delims=" %%i in ('where erl') do (
   set erl=%%i
 )
-@set dir_cmd="%erl%" -noshell -eval "io:format(\"~s\", [filename:nativename(code:root_dir())])." -s init stop
+@set dir_cmd="%erl%" -boot no_dot_erlang -noshell -eval "io:format(\"~s\", [filename:nativename(code:root_dir())])." -s init stop
 @for /f "delims=" %%i in ('%%dir_cmd%%') do (
   set erl_root=%%i
 )

--- a/priv/templates/extended_bin
+++ b/priv/templates/extended_bin
@@ -120,7 +120,7 @@ find_erts_dir() {
     else
         __erl="$(which erl)"
         code="io:format(\"~s\", [code:root_dir()]), halt()."
-        __erl_root="$("$__erl" -noshell -eval "$code")"
+        __erl_root="$("$__erl" -boot no_dot_erlang -noshell -eval "$code")"
         ERTS_DIR="$__erl_root/erts-$ERTS_VSN"
         ROOTDIR="$__erl_root"
     fi

--- a/priv/templates/extended_bin_windows
+++ b/priv/templates/extended_bin_windows
@@ -98,7 +98,7 @@
 @for /f "delims=" %%i in ('where erl') do @(
   set erl=%%i
 )
-@set dir_cmd="%erl%" -noshell -eval "io:format(\"~s\", [filename:nativename(code:root_dir())])." -s init stop
+@set dir_cmd="%erl%" -boot no_dot_erlang -noshell -eval "io:format(\"~s\", [filename:nativename(code:root_dir())])." -s init stop
 @for /f "delims=" %%i in ('%%dir_cmd%%') do @(
   set erl_root=%%i
 )


### PR DESCRIPTION
Any output string from .erlang to stdout will be prepend to
code:root_dir(), so it will cause the retrieved dir incorrect.

The fix is to start erl with the no_dot_erlang boot file.