### PR TITLE
PIPE_DIR handling

### DIFF
--- a/priv/templates/extended_bin
+++ b/priv/templates/extended_bin
@@ -325,6 +325,7 @@ RELX_CONFIG_PATH=$(check_replace_os_vars sys.config $RELX_CONFIG_PATH)
 # Make sure log directory exists
 mkdir -p "$RUNNER_LOG_DIR"
 
+test -z "$PIPE_DIR" && PIPE_BASE_DIR='/tmp/erl_pipes/'
 PIPE_DIR="${PIPE_DIR:-/tmp/erl_pipes/$NAME/}"
 
 # Extract the target cookie
@@ -378,6 +379,7 @@ case "$1" in
         HEART_COMMAND="$RELEASE_ROOT_DIR/bin/$REL_NAME $CMD"
         export HEART_COMMAND
 
+        test -z "$PIPE_BASE_DIR" || mkdir -m 1777 -p "$PIPE_BASE_DIR"
         mkdir -p "$PIPE_DIR"
 
         relx_run_hooks "$PRE_START_HOOKS"


### PR DESCRIPTION
As mentioned in the (closed) issue #127, the default pipe directory is not multi-user friendly. When running multiple relx-generated releases as different users, the first to be started will create the /tmp/erl_pipes directory, which the ones starting after that cannot create their pipe dirs in. The ticket mentions that this should be fixed by #154, but I cannot see how this is supposed to solve the issue. Right now, the only way I see is to use prefix the start command with env PIPE_DIR=/some/other/dir/, which is quite cumbersome.
This change will work exactly as before when PIPE_DIR is explicitly set. In case PIPE_DIR is not set, however, it will first attempt to create the parent dir /tmp/erl_pipes with mode 1777, which should enable releases being run as other users to create their pipe dirs.