### PR TITLE
[windows] pass extra arguments from vm.args to service

### DIFF
--- a/priv/templates/extended_bin_windows
+++ b/priv/templates/extended_bin_windows
@@ -53,6 +53,19 @@
   set cookie=%%J
 )
 
+:: Collect any additional VM args into erl_opts
+@setlocal EnableDelayedExpansion
+@for /f "usebackq tokens=1-2" %%I in (`findstr /r "^[^#]" "%vm_args%"`) do @(
+  if not "%%I" == "-name" (
+    if not "%%I" == "-sname" (
+      if not "%%I" == "-setcookie" (
+        set erl_opts=!erl_opts! %%I %%J
+      )
+    )
+  )
+)
+@endlocal && set erl_opts=%erl_opts%
+
 :: Write the erl.ini file to set up paths relative to this script
 @call :write_ini
 

--- a/priv/templates/extended_bin_windows
+++ b/priv/templates/extended_bin_windows
@@ -53,6 +53,9 @@
   set cookie=%%J
 )
 
+:: Write the erl.ini file to set up paths relative to this script
+@call :write_ini
+
 :: Collect any additional VM args into erl_opts
 @setlocal EnableDelayedExpansion
 @for /f "usebackq tokens=1-2" %%I in (`findstr /r "^[^#]" "%vm_args%"`) do @(
@@ -137,6 +140,17 @@
 ) else (
   set "boot_script=%rel_dir%\start"
 )
+@goto :eof
+
+:: Write the erl.ini file
+:write_ini
+@set erl_ini=%erts_dir%\bin\erl.ini
+@set converted_bindir=%bindir:\=\\%
+@set converted_rootdir=%rootdir:\=\\%
+@echo [erlang] > "%erl_ini%"
+@echo Bindir=%converted_bindir% >> "%erl_ini%"
+@echo Progname=%progname% >> "%erl_ini%"
+@echo Rootdir=%converted_rootdir% >> "%erl_ini%"
 @goto :eof
 
 :: Display usage information

--- a/priv/templates/extended_bin_windows
+++ b/priv/templates/extended_bin_windows
@@ -69,12 +69,6 @@
 )
 @endlocal && set erl_opts=%erl_opts%
 
-:: Remove erl.ini to move the erts_dir freely
-@set erl_ini=%erts_dir%\bin\erl.ini
-@if exist "%erl_ini%" (
-  del "%erl_ini%"
-)
-
 :: If a start.boot file is not present, copy one from the named .boot file
 @if not exist "%rel_dir%\start.boot" (
   copy "%rel_dir%\%rel_name%.boot" "%rel_dir%\start.boot" >nul

--- a/priv/templates/extended_bin_windows
+++ b/priv/templates/extended_bin_windows
@@ -66,6 +66,12 @@
 )
 @endlocal && set erl_opts=%erl_opts%
 
+:: Remove erl.ini to move the erts_dir freely
+@set erl_ini=%erts_dir%\bin\erl.ini
+@if exist "%erl_ini%" (
+  del "%erl_ini%"
+)
+
 :: If a start.boot file is not present, copy one from the named .boot file
 @if not exist "%rel_dir%\start.boot" (
   copy "%rel_dir%\%rel_name%.boot" "%rel_dir%\start.boot" >nul

--- a/priv/templates/extended_bin_windows
+++ b/priv/templates/extended_bin_windows
@@ -66,9 +66,6 @@
 )
 @endlocal && set erl_opts=%erl_opts%
 
-:: Write the erl.ini file to set up paths relative to this script
-@call :write_ini
-
 :: If a start.boot file is not present, copy one from the named .boot file
 @if not exist "%rel_dir%\start.boot" (
   copy "%rel_dir%\%rel_name%.boot" "%rel_dir%\start.boot" >nul
@@ -134,17 +131,6 @@
 ) else (
   set "boot_script=%rel_dir%\start"
 )
-@goto :eof
-
-:: Write the erl.ini file
-:write_ini
-@set erl_ini=%erts_dir%\bin\erl.ini
-@set converted_bindir=%bindir:\=\\%
-@set converted_rootdir=%rootdir:\=\\%
-@echo [erlang] > "%erl_ini%"
-@echo Bindir=%converted_bindir% >> "%erl_ini%"
-@echo Progname=%progname% >> "%erl_ini%"
-@echo Rootdir=%converted_rootdir% >> "%erl_ini%"
 @goto :eof
 
 :: Display usage information


### PR DESCRIPTION
Ref: https://github.com/erlware/relx/issues/439#issuecomment-327468211

This PR will process rest or arguments (except `-name`, `-sname` and `-setcookie`) and include as VM parameters while installing as service in windows.