### PR TITLE
vm.args check for name/sname parameter

### DIFF
--- a/priv/templates/extended_bin
+++ b/priv/templates/extended_bin
@@ -306,27 +306,31 @@ set +e
 TMP_NAME_ARG=$(awk 'function check_name(file)
 {
     if (system("test -f "file)) {
-        print "File \""file"\" not found"
-        exit 1
+        print file" not found"
+        exit 3
+    }
+    if (system("test -r "file)) {
+        print file" not readable"
+        exit 3
     }
     while ((getline line<file)>0) {
         if (line~/^-args_file +/) {
             gsub(/^-args_file +| *$/, "", line)
             if (!(line~/^\//)) {
-                print "Relative path \""line"\" encountered in "file
-                exit 1
+                print "relative path "line" encountered in "file
+                exit 4
             }
             if (line in files) {
-                print "Circular reference to \""line"\" encountered in "file
-                exit 1
+                print "circular reference to "line" encountered in "file
+                exit 5
             }
             files[line]=line
             check_name(line)
         }
         else if (line~/^-s?name +/) {
             if (name!="") {
-                print "\""line"\" found in "file" but specified before as \""name"\""
-                exit 1
+                print "\""line"\" parameter found in "file" but already specified as \""name"\""
+                exit 2
             }
             name=line
         }
@@ -339,20 +343,23 @@ BEGIN {
 }
 
 {
+    files[FILENAME]=FILENAME
     check_name(FILENAME)
     if (name=="") {
-        print "Need to have exactly one of either -name or -sname parameters but none found"
+        print "need to have exactly one of either -name or -sname parameters but none found"
         exit 1
     }
     print name
     exit 0
 }' "$VMARGS_PATH")
-case $? in
+TMP_NAME_ARG_RC=$?
+case $TMP_NAME_ARG_RC in
     0) NAME_ARG="$TMP_NAME_ARG";;
     *) echo "$TMP_NAME_ARG"
-       exit 1;;
+       exit $TMP_NAME_ARG_RC;;
 esac
 unset TMP_NAME_ARG
+unset TMP_NAME_ARG_RC
 set -e
 
 # Perform replacement of variables in ${NAME_ARG}

--- a/priv/templates/extended_bin
+++ b/priv/templates/extended_bin
@@ -294,8 +294,22 @@ export LD_LIBRARY_PATH="$ERTS_DIR/lib:$LD_LIBRARY_PATH"
 ERTS_LIB_DIR="$(dirname "$ERTS_DIR")/lib"
 
 VMARGS_PATH=$(add_path vm.args $VMARGS_PATH)
-# Extract the target node name from node.args
-NAME_ARG=$(egrep '^-s?name' "$VMARGS_PATH" || true)
+# Extract the target node name from vm.args or referenced args_files
+NAME_ARG=$(awk 'function find_name(file) {
+        while ((getline line<file)>0) {
+                if (line~/^-args_file\s+/) {
+                        gsub(/^-args_file\s+/, "", line)
+                        find_name(line)
+                }
+                else if (line~/^-s?name\s+/) {
+                        print line
+                        exit
+                }
+        }
+}
+{
+        find_name(FILENAME)
+}' "$VMARGS_PATH")
 # Perform replacement of variables in ${NAME_ARG}
 NAME_ARG=$(eval echo "${NAME_ARG}")
 

--- a/priv/templates/extended_bin
+++ b/priv/templates/extended_bin
@@ -297,11 +297,11 @@ VMARGS_PATH=$(add_path vm.args $VMARGS_PATH)
 # Extract the target node name from vm.args or referenced args_files
 NAME_ARG=$(awk 'function find_name(file) {
         while ((getline line<file)>0) {
-                if (line~/^-args_file\s+/) {
-                        gsub(/^-args_file\s+/, "", line)
+                if (line~/^-args_file +/) {
+                        gsub(/^-args_file +/, "", line)
                         find_name(line)
                 }
-                else if (line~/^-s?name\s+/) {
+                else if (line~/^-s?name +/) {
                         print line
                         exit
                 }

--- a/priv/templates/extended_bin
+++ b/priv/templates/extended_bin
@@ -296,19 +296,19 @@ ERTS_LIB_DIR="$(dirname "$ERTS_DIR")/lib"
 VMARGS_PATH=$(add_path vm.args $VMARGS_PATH)
 # Extract the target node name from vm.args or referenced args_files
 NAME_ARG=$(awk 'function find_name(file) {
-        while ((getline line<file)>0) {
-                if (line~/^-args_file +/) {
-                        gsub(/^-args_file +/, "", line)
-                        find_name(line)
-                }
-                else if (line~/^-s?name +/) {
-                        print line
-                        exit
-                }
+    while ((getline line<file)>0) {
+        if (line~/^-args_file +/) {
+            gsub(/^-args_file +/, "", line)
+            find_name(line)
         }
+        else if (line~/^-s?name +/) {
+            print line
+            exit
+        }
+    }
 }
 {
-        find_name(FILENAME)
+    find_name(FILENAME)
 }' "$VMARGS_PATH")
 # Perform replacement of variables in ${NAME_ARG}
 NAME_ARG=$(eval echo "${NAME_ARG}")

--- a/priv/templates/extended_bin
+++ b/priv/templates/extended_bin
@@ -294,29 +294,69 @@ export LD_LIBRARY_PATH="$ERTS_DIR/lib:$LD_LIBRARY_PATH"
 ERTS_LIB_DIR="$(dirname "$ERTS_DIR")/lib"
 
 VMARGS_PATH=$(add_path vm.args $VMARGS_PATH)
-# Extract the target node name from vm.args or referenced args_files
-NAME_ARG=$(awk 'function find_name(file) {
+
+# Check vm.args and other files referenced via -args_file parameters for:
+#    - nonexisting -args_files
+#    - circular dependencies of -args_files
+#    - relative paths in -args_file parameters
+#    - multiple/mixed occurences of -name and -sname parameters
+#    - missing -name or -sname parameters
+# If all checks pass, extract the target node name
+set +e
+TMP_NAME_ARG=$(awk 'function check_name(file)
+{
+    if (system("test -f "file)) {
+        print "File \""file"\" not found"
+        exit 1
+    }
     while ((getline line<file)>0) {
         if (line~/^-args_file +/) {
-            gsub(/^-args_file +/, "", line)
-            find_name(line)
+            gsub(/^-args_file +| *$/, "", line)
+            if (!(line~/^\//)) {
+                print "Relative path \""line"\" encountered in "file
+                exit 1
+            }
+            if (line in files) {
+                print "Circular reference to \""line"\" encountered in "file
+                exit 1
+            }
+            files[line]=line
+            check_name(line)
         }
         else if (line~/^-s?name +/) {
-            print line
-            exit
+            if (name!="") {
+                print "\""line"\" found in "file" but specified before as \""name"\""
+                exit 1
+            }
+            name=line
         }
     }
 }
+
+BEGIN {
+    split("", files)
+    name=""
+}
+
 {
-    find_name(FILENAME)
+    check_name(FILENAME)
+    if (name=="") {
+        print "Need to have exactly one of either -name or -sname parameters but none found"
+        exit 1
+    }
+    print name
+    exit 0
 }' "$VMARGS_PATH")
+case $? in
+    0) NAME_ARG="$TMP_NAME_ARG";;
+    *) echo "$TMP_NAME_ARG"
+       exit 1;;
+esac
+unset TMP_NAME_ARG
+set -e
+
 # Perform replacement of variables in ${NAME_ARG}
 NAME_ARG=$(eval echo "${NAME_ARG}")
-
-if [ -z "$NAME_ARG" ]; then
-    echo "vm.args needs to have either -name or -sname parameter."
-    exit 1
-fi
 
 # Extract the name type and name from the NAME_ARG for REMSH
 NAME_TYPE="$(echo "$NAME_ARG" | awk '{print $1}')"


### PR DESCRIPTION
The current version of extended_bin checks if there is a name or sname parameter in vm.args and refuses to start if there is none. However, it is allowed that the vm.args file (more abstract, any -args_file that is given to erl/erlexec etc) itself may contain -args_file parameters (see [http://erlang.org/doc/man/erl.html](http://erlang.org/doc/man/erl.html)), which may contain the name/sname parameters.

This change will recursively scan the files mentioned in -args_file parameters in vm.args as well as -args_file parameters in the mentioned files etcetc, and return the first occurence of a name/sname parameter.

Two points are worth mentioning, though:
- The name/sname check works only with absolute paths in the args_file parameters. Relative paths are probably a bad idea there, anyway, since it would make any setup rather fragile.
- There is no check for circular dependencies. There was none before, and this change does not add any.