### PR TITLE
Add `erts_dir` overlay var

### DIFF
--- a/src/rlx_prv_overlay.erl
+++ b/src/rlx_prv_overlay.erl
@@ -245,6 +245,7 @@ render_overlay_vars(_OverlayVars, [], Acc) ->
 -spec generate_release_vars(rlx_release:t()) -> proplists:proplist().
 generate_release_vars(Release) ->
     [{erts_vsn, rlx_release:erts(Release)},
+     {erts_dir, code:root_dir()},
      {release_erts_version, rlx_release:erts(Release)},
      {release_name, rlx_release:name(Release)},
      {rel_vsn, rlx_release:vsn(Release)},

--- a/test/rlx_release_SUITE.erl
+++ b/test/rlx_release_SUITE.erl
@@ -676,7 +676,8 @@ overlay_release(Config) ->
                              {template, Template,
                               "{{target_dir}}/test_template_resolved"},
                             {template, Template,
-                              "bin/{{default_release_name}}-{{default_release_version}}"}]},
+                              "bin/{{default_release_name}}-{{default_release_version}}"},
+                            {copy, "{{erts_dir}}/bin/erl", "bin/copy.erl"}]},
                   {release, {foo, "0.0.1"},
                    [goal_app_1,
                     goal_app_2]}]),
@@ -728,6 +729,7 @@ overlay_release(Config) ->
     ?assert(ec_file:exists(filename:join([OutputDir, "foo", "foodir", "vars1.config"]))),
     ?assert(ec_file:exists(filename:join([OutputDir, "foo", "yahoo", "vars1.config"]))),
     ?assert(ec_file:exists(filename:join([OutputDir, "foo", SecondTestDir, TestDir, TestFile]))),
+    ?assert(ec_file:exists(filename:join([OutputDir, "foo", "bin", "copy.erl"]))),
 
     TemplateData = case file:consult(filename:join([OutputDir, "foo", "test_template_resolved"])) of
                        {ok, Details} ->


### PR DESCRIPTION
Useful for copying custom files from an erts build
such as a .kerl.config file.