### PR TITLE
Correctly construct HEART_COMMAND and run_erl arguments

### DIFF
--- a/priv/templates/extended_bin
+++ b/priv/templates/extended_bin
@@ -460,7 +460,7 @@ case "$1" in
                 HEART_OPTION="start_boot"
                 ;;
         esac
-        ARGS="$(printf "\'%s\' " "$@")"
+        ARGS="$(printf "'%s' " "$@")"
 
         # Export the HEART_COMMAND
         HEART_COMMAND="\"$RELEASE_ROOT_DIR/bin/$REL_NAME\" \"$HEART_OPTION\" $ARGS"

--- a/priv/templates/extended_bin
+++ b/priv/templates/extended_bin
@@ -460,10 +460,10 @@ case "$1" in
                 HEART_OPTION="start_boot"
                 ;;
         esac
-        RUN_PARAM="$(printf "\'%s\' " "$@")"
+        ARGS="$(printf "\'%s\' " "$@")"
 
         # Export the HEART_COMMAND
-        HEART_COMMAND="$RELEASE_ROOT_DIR/bin/$REL_NAME $HEART_OPTION $RUN_PARAM"
+        HEART_COMMAND="\"$RELEASE_ROOT_DIR/bin/$REL_NAME\" \"$HEART_OPTION\" $ARGS"
         export HEART_COMMAND
 
         test -z "$PIPE_BASE_DIR" || mkdir -m 1777 -p "$PIPE_BASE_DIR"
@@ -471,7 +471,7 @@ case "$1" in
 
         relx_run_hooks "$PRE_START_HOOKS"
         "$BINDIR/run_erl" -daemon "$PIPE_DIR" "$RUNNER_LOG_DIR" \
-            "exec $RELEASE_ROOT_DIR/bin/$REL_NAME $START_OPTION $RUN_PARAM"
+            "exec \"$RELEASE_ROOT_DIR/bin/$REL_NAME\" \"$START_OPTION\" $ARGS"
         relx_run_hooks "$POST_START_HOOKS"
         ;;
 
@@ -623,20 +623,13 @@ case "$1" in
         export EMU
         export PROGNAME
 
-        # Store passed arguments since they will be erased by `set`
-        ARGS="$@"
-
-        # Build an array of arguments to pass to exec later on
-        # Build it here because this command will be used for logging.
-        set -- "$BINDIR/erlexec" $FOREGROUNDOPTIONS \
+        # Dump environment info for logging purposes
+        echo "Exec: $BINDIR/erlexec" $FOREGROUNDOPTIONS \
             -boot "$BOOTFILE" -mode "$CODE_LOADING_MODE" \
             -boot_var ERTS_LIB_DIR "$ERTS_LIB_DIR" \
             -config "$RELX_CONFIG_PATH" \
             -args_file "$VMARGS_PATH" \
-            -pa ${__code_paths}
-
-        # Dump environment info for logging purposes
-        echo "Exec: $@" -- ${1+$ARGS}
+            -pa ${__code_paths} -- "$@"
         echo "Root: $ROOTDIR"
 
         # Log the startup
@@ -644,7 +637,12 @@ case "$1" in
         logger -t "$REL_NAME[$$]" "Starting up"
 
         # Start the VM
-        exec "$@" -- ${1+$ARGS}
+        exec "$BINDIR/erlexec" $FOREGROUNDOPTIONS \
+            -boot "$BOOTFILE" -mode "$CODE_LOADING_MODE" \
+            -boot_var ERTS_LIB_DIR "$ERTS_LIB_DIR" \
+            -config "$RELX_CONFIG_PATH" \
+            -args_file "$VMARGS_PATH" \
+            -pa ${__code_paths} -- "$@"
         ;;
     rpc)
         # Make sure a node IS running

--- a/priv/templates/extended_bin
+++ b/priv/templates/extended_bin
@@ -191,12 +191,6 @@ relx_escript() {
     "$ERTS_DIR/bin/escript" "$ROOTDIR/$scriptpath" $@
 }
 
-# Output a start command for the last argument of run_erl
-relx_start_command() {
-    printf "exec \"%s\" \"%s\"" "$RELEASE_ROOT_DIR/bin/$REL_NAME" \
-           "$START_OPTION"
-}
-
 relx_get_code_paths() {
     code="{ok, [{release,_,_,Apps}]} = file:consult(\"$REL_DIR/$REL_NAME.rel\"),"\
 "lists:foreach(fun(A) ->"\
@@ -454,15 +448,6 @@ cd "$ROOTDIR"
 # Check the first argument for instructions
 case "$1" in
     start|start_boot)
-
-        # Make sure there is not already a node running
-        #RES=`$NODETOOL ping`
-        #if [ "$RES" = "pong" ]; then
-        #    echo "Node is already running!"
-        #    exit 1
-        #fi
-        # Save this for later.
-        CMD=$1
         case "$1" in
             start)
                 shift
@@ -475,14 +460,10 @@ case "$1" in
                 HEART_OPTION="start_boot"
                 ;;
         esac
-        RUN_PARAM="$@"
-
-        # Set arguments for the heart command
-        set -- "$SCRIPT_DIR/$REL_NAME" "$HEART_OPTION"
-        [ "$RUN_PARAM" ] && set -- "$@" "$RUN_PARAM"
+        RUN_PARAM="$(printf "\'%s\' " "$@")"
 
         # Export the HEART_COMMAND
-        HEART_COMMAND="$RELEASE_ROOT_DIR/bin/$REL_NAME $CMD"
+        HEART_COMMAND="$RELEASE_ROOT_DIR/bin/$REL_NAME $HEART_OPTION $RUN_PARAM"
         export HEART_COMMAND
 
         test -z "$PIPE_BASE_DIR" || mkdir -m 1777 -p "$PIPE_BASE_DIR"
@@ -490,7 +471,7 @@ case "$1" in
 
         relx_run_hooks "$PRE_START_HOOKS"
         "$BINDIR/run_erl" -daemon "$PIPE_DIR" "$RUNNER_LOG_DIR" \
-                          "$(relx_start_command)"
+            "exec $RELEASE_ROOT_DIR/bin/$REL_NAME $START_OPTION $RUN_PARAM"
         relx_run_hooks "$POST_START_HOOKS"
         ;;
 


### PR DESCRIPTION
The runner script that ships with `rebar` builds `HEART_COMMAND` and `run_erl` arguments in such a way to preserve additional arguments the user may have passed:

https://github.com/rebar/rebar/blob/master/priv/templates/simplenode.runner#L215-L238

This PR preserves this behavior.

In addition, the current code on this line sets `$@` but does not do anything with the result:

https://github.com/erlware/relx/blob/master/priv/templates/extended_bin#L481-L482

Investigated in response to this ML thread: http://erlang.org/pipermail/erlang-questions/2017-October/093974.html