### PR TITLE
Fix release upgrades on Windows

### DIFF
--- a/priv/templates/extended_bin_windows
+++ b/priv/templates/extended_bin_windows
@@ -48,6 +48,12 @@
   set node_name=%%J
 )
 
+@if "-sname" == "%node_type%" (
+  set hostname="%COMPUTERNAME%"
+) else (
+  set hostname="%COMPUTERNAME%.%USERDNSDOMAIN%
+)
+
 :: Extract cookie from vm.args
 @for /f "usebackq tokens=1-2" %%I in (`findstr /b \-setcookie "%vm_args%"`) do @(
   set cookie=%%J
@@ -160,9 +166,7 @@ set start_erl=%erts_dir%\bin\start_erl.exe
 set description=Erlang node %node_name% in %rootdir%
 @if "" == "%2" (
   :: Install the service
-  %erlsrv% add %service_name% %node_type% "%node_name%" -c "%description%" ^
-            -w "%rootdir%" -m "%start_erl%" -args "%args%" ^
-            -stopaction "init:stop()."
+  %erlsrv% add %service_name% %node_type% "%node_name%" -c "%description%" -w "%rootdir%" -m "%start_erl%" -args "%args%" -stopaction "init:stop()."
 ) else (
   :: relup and reldown
   goto relup
@@ -193,7 +197,7 @@ set description=Erlang node %node_name% in %rootdir%
   set ERRORLEVEL=1
   exit /b %ERRORLEVEL%
 )
-@%escript% "%rootdir%/bin/install_upgrade.escript" "install" "%rel_name%" "%node_name%" "%cookie%" "%2"
+@%escript% "%rootdir%/bin/install_upgrade.escript" "install" "{'%rel_name%', \"%node_type%\", '%node_name%@%hostname%', '%cookie%'}" "%2" "%3"
 @goto :eof
 
 :: Start a console

--- a/priv/templates/install_upgrade_escript
+++ b/priv/templates/install_upgrade_escript
@@ -207,7 +207,12 @@ find_and_link_release_package(Version, RelName) ->
             ok = filelib:ensure_dir(filename:join([filename:dirname(ReleaseLink), "dummy"])),
             %% create the symlink pointing to the full path name of the
             %% release package we found
-            ok = file:make_symlink(filename:absname(Filename), ReleaseLink),
+            case file:make_symlink(filename:absname(Filename), ReleaseLink) of
+                ok ->
+                    ok;
+                {error, eperm} -> % windows!
+                    {ok,_} = file:copy(filename:absname(Filename), ReleaseLink)
+            end,
             {Filename, ReleaseHandlerPackageLink}
     end.
 
@@ -311,7 +316,7 @@ start_distribution(TargetNode, NameTypeArg, Cookie) ->
         {true, pong} ->
             ok;
         {_, pang} ->
-            io:format("Node ~p not responding to pings.\n", [TargetNode]),
+            ?INFO("Node ~p not responding to pings.\n", [TargetNode]),
             erlang:halt(1)
     end,
     {ok, Cwd} = file:get_cwd(),


### PR DESCRIPTION
Some tool calls were outdated, and in some cases, relied on non-existing
features there.