### PR TITLE
Windows: support remote_console, fix attach

### DIFF
--- a/priv/templates/extended_bin_windows
+++ b/priv/templates/extended_bin_windows
@@ -10,6 +10,7 @@
 :: * ping - check if the node is running
 :: * console - start the Erlang release in a `werl` Windows shell
 :: * attach - connect to a running node and open an interactive console
+:: * remote_console - alias for attach
 :: * list - display a listing of installed Erlang services
 :: * usage - display available commands
 
@@ -91,6 +92,7 @@
 @if "%1"=="ping" @goto ping
 @if "%1"=="list" @goto list
 @if "%1"=="attach" @goto attach
+@if "%1"=="remote_console" @goto attach
 @if "%1"=="" @goto usage
 @echo Unknown command: "%1"
 
@@ -155,7 +157,7 @@
 
 :: Display usage information
 :usage
-@echo usage: %~n0 ^(install^|uninstall^|start^|stop^|restart^|upgrade^|downgrade^|console^|ping^|list^|attach^)
+@echo usage: %~n0 ^(install^|uninstall^|start^|stop^|restart^|upgrade^|downgrade^|console^|ping^|list^|attach^|remote_console^)
 @goto :eof
 
 :: Install the release as a Windows service
@@ -221,5 +223,5 @@ set description=Erlang node %node_name% in %rootdir%
 :attach
 @set boot=-boot "%clean_boot_script%" -boot_var RELEASE_DIR "%release_root_dir%"
 @start "%node_name% attach" %werl% %boot% ^
-       -remsh %node_name% %node_type% console -setcookie %cookie%
+       -remsh %node_name%@%hostname% %node_type% console -setcookie %cookie%
 @goto :eof


### PR DESCRIPTION
On Linux, 'attach' uses named pipes, and 'remote_console' uses -remsh.
The latter is usually deemed better since named pipes require a call to
fsync on every line written.

On Windows, no named pipes are available so attach uses -remsh directly.
Historically, remote_console was added to linux *after* attach, but no
alias was added for it on windows. Since there's a predominance of
tutorials using linux-likes, remote_console is widely documented as the
way to go, and is unavailable on windows.

This is hella confusing.

So to work around that, this patch adds an alias for 'attach' on windows
to be 'remote_console', bridging the gap.

Also the functionality was flat out broken because it would not use a
node hostname when connecting out. Since the latest release added that
functionality, this patch also fixes attach to work in the first place.