### PR TITLE
Add unused variables on replace OS vars test

### DIFF
--- a/test/rlx_extended_bin_SUITE.erl
+++ b/test/rlx_extended_bin_SUITE.erl
@@ -436,7 +436,9 @@ replace_os_vars(Config) ->
                  ]),
 
     rlx_test_utils:write_config(SysConfig,
-                                [[{goal_app, [{var1, "${VAR1}"}]}]]),
+                                [[{goal_app,
+                                   [{var1, "${VAR1}"},
+                                    {var2, "${VAR2}"}]}]]),
     ec_file:write(VmArgs, "-sname ${NODENAME}\n\n"
                           "-setcookie ${COOKIE}\n"),
 


### PR DESCRIPTION
To prevent further regressions such as the one found in
erlware/relx#627.