### PR TITLE
Issue 629: Ability to install hot patches

### DIFF
--- a/priv/templates/extended_bin
+++ b/priv/templates/extended_bin
@@ -115,7 +115,7 @@ relx_usage() {
                 relx_run_extension $EXTENSION_SCRIPT help
             else
                 EXTENSIONS=`echo $EXTENSIONS | sed -e 's/|undefined//g'`
-                echo "Usage: $REL_NAME {start|start_boot <file>|foreground|stop|restart|reboot|pid|ping|console|console_clean|console_boot <file>|attach|remote_console|upgrade|downgrade|install|uninstall|versions|escript|rpc|rpcterms|eval|status|$EXTENSIONS}"
+                echo "Usage: $REL_NAME {start|start_boot <file>|foreground|stop|restart|reboot|pid|ping|console|console_clean|console_boot <file>|attach|remote_console|upgrade|downgrade|install|uninstall|hotpatch|versions|escript|rpc|rpcterms|eval|status|$EXTENSIONS}"
             fi
             ;;
     esac
@@ -566,6 +566,25 @@ case "$1" in
              "$COMMAND" "{'$REL_NAME', \"$NAME_TYPE\", '$NAME', '$COOKIE'}" "$@"
 
         relx_run_hooks "$POST_INSTALL_UPGRADE_HOOKS"
+        ;;
+
+    hotpatch)
+        if [ -z "$2" ]; then
+            echo "Missing files list"
+            echo "Usage: $REL_NAME $1 {list of files}"
+            exit 1
+        fi
+
+        COMMAND="$1"; shift
+
+        # Make sure a node IS running
+        if ! relx_nodetool "ping" > /dev/null; then
+            echo "Node is not running!"
+            exit 1
+        fi
+
+        exec "$BINDIR/escript" "$ROOTDIR/bin/install_upgrade.escript" \
+             "$COMMAND" "{'$REL_NAME', \"$NAME_TYPE\", '$NAME', '$COOKIE'}" "$@"
         ;;
 
     versions)

--- a/priv/templates/install_upgrade_escript
+++ b/priv/templates/install_upgrade_escript
@@ -6,6 +6,11 @@
 -define(TIMEOUT, 300000).
 -define(INFO(Fmt,Args), io:format(Fmt,Args)).
 
+main(["hotpatch", DistInfoStr | CommandArgs]) ->
+    %% convert the distribution info arguments string to an erlang term
+    {ok, Tokens, _} = erl_scan:string(DistInfoStr ++ "."),
+    {ok, DistInfo} = erl_parse:parse_term(Tokens),
+    hotpatch(DistInfo, CommandArgs);
 main([Command0, DistInfoStr | CommandArgs]) ->
     %% convert the distribution info arguments string to an erlang term
     {ok, Tokens, _} = erl_scan:string(DistInfoStr ++ "."),
@@ -126,6 +131,34 @@ uninstall({_RelName, NameTypeArg, NodeName, Cookie}, Opts) ->
     end;
 uninstall(_, Args) ->
     ?INFO("uninstall: unknown args ~p\n", [Args]).
+
+
+hotpatch({_, NameTypeArg, NodeName, Cookie}, FilesList) ->
+    TargetNode = start_distribution(NodeName, NameTypeArg, Cookie),
+    hotpatch(TargetNode, FilesList);
+
+hotpatch(_, []) ->
+    ok;
+hotpatch(TargetNode, [FileName|Rest]) ->
+    io:format("Loading ~s: ", [FileName]),
+    Module = erlang:list_to_atom(filename:basename(FileName,".beam")),
+    {ok,NewBinary} = file:read_file(FileName),
+    case rpc:call(TargetNode, code, get_object_code, [Module]) of
+        {Module, OldBinary, _} when NewBinary == OldBinary ->
+            %% File exists, and binaries are same.
+            io:format("no change~n", []);
+        {Module, _, ReleaseFilePath} ->
+            %% File exists, overwrite and load into VM.
+            ok = rpc:call(TargetNode, file, write_file, [ReleaseFilePath, NewBinary]),
+            io:format("done~n", []),
+            rpc:call(TargetNode, code, purge, [Module]),
+            {module, Module} = rpc:call(TargetNode, code, load_file, [Module]);
+        _ ->
+            %% File doesn't exist, just load into VM.
+            io:format("file does not exist, just loading binary~n", []),
+            {module, Module} = rpc:call(TargetNode, code, load_binary, [Module, undefined, NewBinary])
+    end,
+    hotpatch(TargetNode, Rest).
 
 versions({_RelName, NameTypeArg, NodeName, Cookie}, []) ->
     TargetNode = start_distribution(NodeName, NameTypeArg, Cookie),


### PR DESCRIPTION
Adds a new option hotpatch to list of options to extended_bin

From release directory one can do:

`./bin/<release-name> hotpatch <List of beam files>`

For example, for a project foo, trying to add 3 beam files which are in different directories.

```
root@5a00493145e7# ./bin/foo hotpatch patch/a.beam patch/b.beam somedir/c.beam
Loading patch/a.beam: done
Loading patch/b.beam: no change
Loading somedir/c.beam: file does not exist, just loading binary

```
In above example,

1. a.beam is indeed modified, so it is loaded.
2. b.beam is same as the one that is being in use, so no change is made
3. c.beam is a new beam file which is not known to the project. So, the binary is just loaded into the Erlang VM. It is expected that user does a full software upgrade via package file mechanism so that file physically exists in the system.