### PR TITLE
Fix backup file creation by sed

### DIFF
--- a/priv/templates/extended_bin
+++ b/priv/templates/extended_bin
@@ -233,14 +233,16 @@ replace_os_vars() {
 escript_emulator_args() {
     if [ -n "${VM_ARGS}" ]; then
         if grep -q '%%!' $1; then
-            cmd=$(echo sed -i"' '" "'/%%!.*/ s| ${VM_ARGS}||'" $1)
+            cmd=$(echo sed -i"'.prev'" "'/%%!.*/ s| ${VM_ARGS}||'" $1)
             eval "$cmd"
-            cmd=$(echo sed -i"' '" "'/%%!.*/ s|$| ${VM_ARGS}|'" $1)
+            cmd=$(echo sed -i"'.prev'" "'/%%!.*/ s|$| ${VM_ARGS}|'" $1)
             eval "$cmd"
+            rm ${1}.prev
         else
-            cmd=$(echo sed -i"' '" "'/#!.*/ a \\
+            cmd=$(echo sed -i"'.prev'" "'/#!.*/ a \\
 %%! ${VM_ARGS}\n'" $1)
             eval "$cmd"
+            rm ${1}.prev
         fi
     fi
 }

--- a/priv/templates/extended_bin
+++ b/priv/templates/extended_bin
@@ -352,6 +352,9 @@ ERTS_LIB_DIR="$(dirname "$ERTS_DIR")/lib"
 
 VMARGS_PATH=$(add_path vm.args $VMARGS_PATH)
 
+VMARGS_PATH=$(check_replace_os_vars vm.args $VMARGS_PATH)
+RELX_CONFIG_PATH=$(check_replace_os_vars sys.config $RELX_CONFIG_PATH)
+
 # Check vm.args and other files referenced via -args_file parameters for:
 #    - nonexisting -args_files
 #    - circular dependencies of -args_files
@@ -436,9 +439,6 @@ esac
 
 # Export the variable so that it's available in the 'eval' calls
 export NAME
-
-VMARGS_PATH=$(check_replace_os_vars vm.args $VMARGS_PATH)
-RELX_CONFIG_PATH=$(check_replace_os_vars sys.config $RELX_CONFIG_PATH)
 
 # Make sure log directory exists
 mkdir -p "$RUNNER_LOG_DIR"


### PR DESCRIPTION
1. Fix previously introduced behaviour with creation space terminated file in sed, i.e. "nodetool" backups to "nodetool ".
2. Reorder check_replace_os_vars with NODE name assignment.