### PR TITLE
add -heart to args not to be copied to nodetool

### DIFF
--- a/priv/templates/extended_bin
+++ b/priv/templates/extended_bin
@@ -461,7 +461,7 @@ else
     COOKIE="$(echo "$COOKIE_ARG" | awk '{print $2}')"
 fi
 
-VM_ARGS="$(grep -v -E '^#|^-name|^-sname|^-setcookie|^-args_file' "$VMARGS_PATH" | xargs | sed -e 's/ / /g')"
+VM_ARGS="$(grep -v -E '^#|^-name|^-sname|^-setcookie|^-heart|^-args_file' "$VMARGS_PATH" | xargs | sed -e 's/ / /g')"
 
 cd "$ROOTDIR"
 


### PR DESCRIPTION
The current version of extended_bin copies flags from vm.args to nodetool. The flags excluded from copying did not consider the `-heart` flag, which in turn causes some confusing output from heart when nodetool is used later on (ping, remote_console, stop, ...):

```
heart_beat_kill_pid = 4010
pong
heart: Wed May 30 16:05:11 2018: Erlang has closed.
heart: Wed May 30 16:05:11 2018: Would reboot. Terminating.
```

This PR adds the `-heart` flag to the flags to be excluded.

Thanks to @essen for helping in finding the reason for this issue :)