### PR TITLE
Drop OTP R15/16 from Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,6 @@ matrix:
   include:
     - os: linux
       sudo: required
-      otp_release: R15B03
-    - os: linux
-      sudo: required
-      otp_release: R16B03-1
-    - os: linux
-      sudo: required
       otp_release: 17.5
     - os: linux
       sudo: required


### PR DESCRIPTION
rebar3 has dropped support for these so relx
needs to go along with the program.