### PR TITLE
Support wildcards for copy/link to a directory.

### DIFF
--- a/src/rlx_prv_overlay.erl
+++ b/src/rlx_prv_overlay.erl
@@ -381,7 +381,7 @@ wildcard_copy(State, FromFile0, ToFile0, CopyFun, ErrorTag) ->
                   filelib:ensure_dir(ToFile1),
                   CopyFun(FromFile1, ToFile1);
               true ->
-                  Root = absolute_path_from("."),
+                  Root = absolute_path_from(State, "."),
                   FromFiles = if
                       is_list(FromFile0) -> filelib:wildcard(FromFile0, Root);
                       true -> [FromFile1]

--- a/src/rlx_prv_overlay.erl
+++ b/src/rlx_prv_overlay.erl
@@ -381,15 +381,16 @@ wildcard_copy(State, FromFile0, ToFile0, CopyFun, ErrorTag) ->
                   filelib:ensure_dir(ToFile1),
                   CopyFun(FromFile1, ToFile1);
               true ->
+                  Root = absolute_path_from(Root),
                   FromFiles = if
-                      is_list(FromFile1) -> filelib:wildcard(FromFile1);
+                      is_list(FromFile0) -> filelib:wildcard(FromFile0, Root);
                       true -> [FromFile1]
                   end,
                   rlx_util:mkdir_p(ToFile1),
                   lists:foldl(fun
                       (_, {error, _} = Error) -> Error;
                       (FromFile, ok) ->
-                          CopyFun(FromFile, filename:join(ToFile1, filename:basename(FromFile)))
+                          CopyFun(filename:join(Root, FromFile), filename:join(ToFile1, filename:basename(FromFile)))
                   end, ok, FromFiles)
     end,
                   

--- a/src/rlx_prv_overlay.erl
+++ b/src/rlx_prv_overlay.erl
@@ -381,7 +381,7 @@ wildcard_copy(State, FromFile0, ToFile0, CopyFun, ErrorTag) ->
                   filelib:ensure_dir(ToFile1),
                   CopyFun(FromFile1, ToFile1);
               true ->
-                  Root = absolute_path_from(Root),
+                  Root = absolute_path_from("."),
                   FromFiles = if
                       is_list(FromFile0) -> filelib:wildcard(FromFile0, Root);
                       true -> [FromFile1]

--- a/test/rlx_extended_bin_SUITE.erl
+++ b/test/rlx_extended_bin_SUITE.erl
@@ -1294,10 +1294,7 @@ custom_start_script_hooks(Config) ->
                         ]}
                     ]},
                   {mkdir, "scripts"},
-                  {overlay, [{copy, "./pre_start", "bin/hooks/pre_start"},
-                             {copy, "./post_start", "bin/hooks/post_start"},
-                             {copy, "./pre_stop", "bin/hooks/pre_stop"},
-                             {copy, "./post_stop", "bin/hooks/post_stop"}]}
+                  {overlay, [{copy, "./{pre,post}_{start,stop}", "bin/hooks/"}]}
                  ]),
 
     %% write the hook scripts, each of them will write an erlang term to a file

--- a/test/rlx_release_SUITE.erl
+++ b/test/rlx_release_SUITE.erl
@@ -669,7 +669,7 @@ overlay_release(Config) ->
                   {overlay, [{mkdir, "{{target_dir}}/fooo"},
                              {copy, OverlayVars1,
                               "{{target_dir}}/{{foo_dir}}/vars1.config"},
-                             {copy, OverlayVars1,
+                             {copy, filename:join([LibDir1, "vars1*.config"]),
                               "{{target_dir}}/{{yahoo}}/"},
                              {link, OverlayVars4,
                               "{{target_dir}}/{{yahoo}}/vars4.config"},


### PR DESCRIPTION
Additionally, removes a lot of unnecessary conversions to binary in
relx_prv_overlay (binary and string in Erlang are two different beasts
for filenames), and factors out some common code.