### PR TITLE
run named erl nodes to auto-set cookie

### DIFF
--- a/priv/templates/extended_bin
+++ b/priv/templates/extended_bin
@@ -127,10 +127,12 @@ find_erts_dir() {
     if [ -d "$__erts_dir" ]; then
         ERTS_DIR="$__erts_dir";
         ROOTDIR="$RELEASE_ROOT_DIR"
+        # run a dummy distributed erlang node just to ensure that a cookie exists
+        $ERTS_DIR/bin/erl -sname dummy -boot no_dot_erlang -noshell -eval "halt()"
     else
         __erl="$(which erl)"
         code="io:format(\"~s\", [code:root_dir()]), halt()."
-        __erl_root="$("$__erl" -boot no_dot_erlang -sasl errlog_type error -noshell -eval "$code")"
+        __erl_root="$("$__erl" -sname dummy -boot no_dot_erlang -sasl errlog_type error -noshell -eval "$code")"
         ERTS_DIR="$__erl_root/erts-$ERTS_VSN"
         ROOTDIR="$__erl_root"
     fi

--- a/priv/templates/extended_bin_windows
+++ b/priv/templates/extended_bin_windows
@@ -137,7 +137,7 @@
 @for /f "delims=" %%i in ('where erl') do @(
   set erl=%%i
 )
-@set dir_cmd="%erl%" -boot no_dot_erlang -noshell -eval "io:format(\"~s\", [filename:nativename(code:root_dir())])." -s init stop
+@set dir_cmd="%erl%" -sname dummy -boot no_dot_erlang -noshell -eval "io:format(\"~s\", [filename:nativename(code:root_dir())])." -s init stop
 @for /f "delims=" %%i in ('%%dir_cmd%%') do @(
   set erl_root=%%i
 )


### PR DESCRIPTION
If no cookie is set in `vm.args` and no distributed erlang node has yet run on the machine, there will be no local cookie, and startup will fail.

This change ensures that a distributed node has at least started as part of the routine checks performed by the script, thus ensuring a local cookie file.