### PR TITLE
fix handling of default_release in config

### DIFF
--- a/src/rlx_config.erl
+++ b/src/rlx_config.erl
@@ -339,6 +339,9 @@ merge_configs([{Key, Value} | CliTerms], ConfigTerms) ->
                 false ->
                     merge_configs(CliTerms, ConfigTerms++[{Key, Value}])
             end;
+        default_release when Value =:= {undefined, undefined} ->
+            %% No release specified in cli. Prevent overwriting default_release in ConfigTerms.
+            merge_configs(CliTerms, lists:keymerge(1, ConfigTerms, [{Key, Value}]));
         _ ->
             merge_configs(CliTerms, lists:reverse(lists:keystore(Key, 1, lists:reverse(ConfigTerms), {Key, Value})))
     end.


### PR DESCRIPTION
Fixes #650 and https://github.com/erlang/rebar3/issues/1629.

When no release specified in cli, prevent overwriting default_release
in relx config.

The issue this PR fixes is the following:
create a new rebar3 release project by
```
rebar3 new release a
cd a/apps
rebar3 new app b
cd ..
```
edit `rebar.config`
```
{relx, [{default_release, {b, "0.1.0"}},
        {release, {a, "0.1.0"},
         [a,
          sasl]},
        {release, {b, "0.1.0"},
         [b,
          sasl]}
]}.
```

`rebar3 release` does not pick up the configured `default_release` but shows error instead:
```
===> No default release name was specified and there are multiple releases in the config: b, a
```
