### PR TITLE
Enable passing arguments with spaces to extensions

### DIFF
--- a/priv/templates/extended_bin
+++ b/priv/templates/extended_bin
@@ -371,7 +371,7 @@ relx_run_extension() {
     shift
     # all extension script locations are expected to be
     # relative to the start script location
-    [ "$SCRIPT_DIR/$EXTENSION_SCRIPT" ] && . "$SCRIPT_DIR/$EXTENSION_SCRIPT" $@
+    [ "$SCRIPT_DIR/$EXTENSION_SCRIPT" ] && . "$SCRIPT_DIR/$EXTENSION_SCRIPT" "$@"
 }
 
 # given a list of arguments, identify the internal ones
@@ -791,7 +791,7 @@ case "$1" in
         if [ "$IS_EXTENSION" = "1" ]; then
             EXTENSION_SCRIPT=$(relx_get_extension_script $1)
             shift
-            relx_run_extension $EXTENSION_SCRIPT $@
+            relx_run_extension $EXTENSION_SCRIPT "$@"
             # all extension scripts are expected to exit
         else
             relx_usage $1


### PR DESCRIPTION
Hi,

Is passing arguments with spaces to extensions not possible on purpose? Would you consider a patch supporting that? I did not look yet into how easy it would be to add a test in relx for this case.

I was testing passing arguments with spaces to a rebar3 extension and I was not managing to do so until I amended manually the relx extended bin itself in my OTP release (rebar3 3.5.0 hence relx 3.24.3, though the script seems not changed much in master in this regard). I re-applied these changes to git so to propose them to you though I did not perform extensive testing on this patch.