### PR TITLE
[UPDATED] Fix renaming of .orig configuration files on Windows

### DIFF
--- a/priv/templates/bin_windows
+++ b/priv/templates/bin_windows
@@ -73,6 +73,23 @@ cd %rootdir%
 @set "possible_sys=%rel_dir%\sys.config"
 @if exist "%possible_sys%" (
   set sys_config=-config "%possible_sys%"
+) else (
+  @if exist "%possible_sys%.orig" (
+    ren "%possible_sys%.orig" sys.config
+    set sys_config=-config "%possible_sys%"
+  )
+)
+
+:: Find the vm.args file
+:find_vm_args
+@set "possible_vm_args=%rel_dir%\vm.args"
+@if exist "%possible_vm_args%" (
+  set vm_args="%possible_vm_args%"
+) else (
+  @if exist "%possible_vm_args%.orig" (
+    ren "%possible_vm_args%.orig" vm.args
+    set vm_args="%possible_vm_args%"
+  )
 )
 @goto :eof
 

--- a/priv/templates/extended_bin_windows
+++ b/priv/templates/extended_bin_windows
@@ -148,15 +148,21 @@
 :: Find the sys.config file
 :find_sys_config
 @set "possible_sys=%rel_dir%\sys.config"
-@if exist %possible_sys% (
+@if exist "%possible_sys%" (
   set sys_config=-config "%possible_sys%"
+) else (
+  @if exist "%possible_sys%.orig" (
+    ren "%possible_sys%.orig" sys.config
+    set sys_config=-config "%possible_sys%"
+  )
 )
-@if exist "%possible_sys%.orig" (
-  ren "%possible_sys%.orig" sys.config
-  set sys_config=-config "%possible_sys%"
-)
-@if exist "%rel_dir%\vm.args.orig" (
-  ren "%rel_dir%\vm.args.orig" vm.args
+
+:: Find the vm.args file
+:find_vm_args
+@if not exist "%m_args%" (
+  @if exist "%m_args%.orig" (
+    ren "%m_args%.orig" vm.args
+  )
 )
 @goto :eof
 

--- a/priv/templates/extended_bin_windows
+++ b/priv/templates/extended_bin_windows
@@ -151,6 +151,13 @@
 @if exist %possible_sys% (
   set sys_config=-config "%possible_sys%"
 )
+@if exist "%possible_sys%.orig" (
+  ren "%possible_sys%.orig" sys.config
+  set sys_config=-config "%possible_sys%"
+)
+@if exist "%rel_dir%\vm.args.orig" (
+  ren "%rel_dir%\vm.args.orig" vm.args
+)
 @goto :eof
 
 :: set boot_script variable


### PR DESCRIPTION
I've updated the original #468 to the latest master and extended the change to include `vm.args` as well like already done in the unix variant of the bin scripts.