### PR TITLE
don't create world writable executables

### DIFF
--- a/src/rlx_prv_assembler.erl
+++ b/src/rlx_prv_assembler.erl
@@ -433,13 +433,13 @@ write_bin_file(State, Release, OutputDir, RelDir) ->
                 win32 -> rlx_string:concat(VsnRel, ".cmd")
             end,
             ok = file:write_file(VsnRelStartFile, StartFile),
-            ok = file:change_mode(VsnRelStartFile, 8#777),
+            ok = file:change_mode(VsnRelStartFile, 8#755),
             BareRelStartFile = case OsFamily of
                 unix -> BareRel;
                 win32 -> rlx_string:concat(BareRel, ".cmd")
             end,
             ok = file:write_file(BareRelStartFile, StartFile),
-            ok = file:change_mode(BareRelStartFile, 8#777)
+            ok = file:change_mode(BareRelStartFile, 8#755)
     end,
     ReleasesDir = filename:join(OutputDir, "releases"),
     generate_start_erl_data_file(Release, ReleasesDir),


### PR DESCRIPTION
When releases are assembled the permissions of various executables are set.  For some reason the start scripts were set to 8#777 whereas all the others were being set to 8#755.  8#755 seems safer, so this sets the start script to be the same.