### PR TITLE
Refactor creation of .erlang.cookie for use in start/console procedures

### DIFF
--- a/priv/templates/extended_bin
+++ b/priv/templates/extended_bin
@@ -124,15 +124,16 @@ relx_usage() {
 
 find_erts_dir() {
     __erts_dir="$RELEASE_ROOT_DIR/erts-$ERTS_VSN"
+    DUMMY_NAME="dummy-$(relx_gen_id)"
     if [ -d "$__erts_dir" ]; then
         ERTS_DIR="$__erts_dir";
         ROOTDIR="$RELEASE_ROOT_DIR"
         # run a dummy distributed erlang node just to ensure that a cookie exists
-        $ERTS_DIR/bin/erl -sname dummy -boot no_dot_erlang -noshell -eval "halt()"
+        $ERTS_DIR/bin/erl -sname ${DUMMY_NAME} -boot no_dot_erlang -noshell -eval "halt()"
     else
         __erl="$(which erl)"
         code="io:format(\"~s\", [code:root_dir()]), halt()."
-        __erl_root="$("$__erl" -sname dummy -boot no_dot_erlang -sasl errlog_type error -noshell -eval "$code")"
+        __erl_root="$("$__erl" -sname ${DUMMY_NAME} -boot no_dot_erlang -sasl errlog_type error -noshell -eval "$code")"
         ERTS_DIR="$__erl_root/erts-$ERTS_VSN"
         ROOTDIR="$__erl_root"
     fi

--- a/priv/templates/extended_bin
+++ b/priv/templates/extended_bin
@@ -19,7 +19,7 @@ fi
 
 # OSX does not support readlink '-f' flag, work
 # around that
-case $OSTYPE in 
+case $OSTYPE in
     darwin*)
         SCRIPT=$(readlink $0 || true)
     ;;
@@ -124,19 +124,27 @@ relx_usage() {
 
 find_erts_dir() {
     __erts_dir="$RELEASE_ROOT_DIR/erts-$ERTS_VSN"
-    DUMMY_NAME="dummy-$(relx_gen_id)"
     if [ -d "$__erts_dir" ]; then
         ERTS_DIR="$__erts_dir";
         ROOTDIR="$RELEASE_ROOT_DIR"
-        # run a dummy distributed erlang node just to ensure that a cookie exists
-        $ERTS_DIR/bin/erl -sname ${DUMMY_NAME} -boot no_dot_erlang -noshell -eval "halt()"
     else
         __erl="$(which erl)"
         code="io:format(\"~s\", [code:root_dir()]), halt()."
-        __erl_root="$("$__erl" -sname ${DUMMY_NAME} -boot no_dot_erlang -sasl errlog_type error -noshell -eval "$code")"
+        __erl_root="$("$__erl" -boot no_dot_erlang -sasl errlog_type error -noshell -eval "$code")"
         ERTS_DIR="$__erl_root/erts-$ERTS_VSN"
         ROOTDIR="$__erl_root"
     fi
+}
+
+ensure_dot_erlang_cookie() {
+  # Run a dummy distributed erlang node just to ensure that $HOME/.erlang.cookie exists.
+  # This action is best-effort and could fail because of the way the system is set up.
+  # Failures are logged, but ignored.
+  DUMMY_NAME="dummy-$(relx_gen_id)"
+  if ! output="$($ERTS_DIR/bin/erl -sname ${DUMMY_NAME} -boot no_dot_erlang -noshell -eval "halt()")"
+  then
+    echo "Creating .erlang.cookie failed: ${output}"
+  fi
 }
 
 # Get node pid
@@ -311,10 +319,10 @@ relx_is_extension() {
     EXTENSION=$1
     case "$EXTENSION" in
         {{{ extensions }}})
-            echo "1" 
+            echo "1"
         ;;
         *)
-            echo "0" 
+            echo "0"
         ;;
     esac
 }
@@ -325,7 +333,7 @@ relx_get_extension_script() {
     # of the form:
     # foo_extension="path/to/foo_script";bar_extension="path/to/bar_script"
     {{{extension_declarations}}}
-    # get the command extension (eg. foo) and 
+    # get the command extension (eg. foo) and
     # obtain the actual script filename that it
     # refers to (eg. "path/to/foo_script"
     eval echo "$"${EXTENSION}_extension""
@@ -513,6 +521,8 @@ case "$1" in
         # Make sure log directory exists
         mkdir -p "$RUNNER_LOG_DIR"
 
+        ensure_dot_erlang_cookie
+
         relx_run_hooks "$PRE_START_HOOKS"
         "$BINDIR/run_erl" -daemon "$PIPE_DIR" "$RUNNER_LOG_DIR" \
             "exec \"$RELEASE_ROOT_DIR/bin/$REL_NAME\" \"$START_OPTION\" $ARGS --relx-disable-hooks"
@@ -682,6 +692,8 @@ case "$1" in
             -args_file "$VMARGS_PATH" \
             -pa ${__code_paths} -- "$@"
         echo "Root: $ROOTDIR"
+
+        ensure_dot_erlang_cookie
 
         # Log the startup
         echo "$RELEASE_ROOT_DIR"

--- a/priv/templates/extended_bin_windows
+++ b/priv/templates/extended_bin_windows
@@ -159,20 +159,20 @@
 :find_sys_config
 @set "possible_sys=%rel_dir%\sys.config"
 @if exist "%possible_sys%" (
-  set "sys_config=-config \"%possible_sys%\""
+  set sys_config=-config "%possible_sys%"
 ) else (
   @if exist "%possible_sys%.orig" (
     ren "%possible_sys%.orig" sys.config
-    set "sys_config=-config \"%possible_sys%\""
+    set sys_config=-config "%possible_sys%"
   )
 )
 @goto :eof
 
 :: Find the vm.args file
 :find_vm_args
-@if not exist "%m_args%" (
-  @if exist "%m_args%.orig" (
-    ren "%m_args%.orig" vm.args
+@if not exist "%vm_args%" (
+  @if exist "%vm_args%.orig" (
+    ren "%vm_args%.orig" vm.args
   )
 )
 @goto :eof

--- a/priv/templates/extended_bin_windows
+++ b/priv/templates/extended_bin_windows
@@ -37,17 +37,18 @@
 @set vm_args=%rel_dir%\vm.args
 @set progname=erl.exe
 @set clean_boot_script=%release_root_dir%\bin\start_clean
-@set erlsrv="%bindir%\erlsrv.exe"
-@set epmd="%bindir%\epmd.exe"
-@set escript="%bindir%\escript.exe"
-@set werl="%bindir%\werl.exe"
-@set nodetool="%release_root_dir%\bin\nodetool"
+@set "erlsrv=%bindir%\erlsrv.exe"
+@set "epmd=%bindir%\epmd.exe"
+@set "escript=%bindir%\escript.exe"
+@set "werl=%bindir%\werl.exe"
+@set "erl=%bindir%\erl.exe"
+@set "nodetool=%release_root_dir%\bin\nodetool"
 @set "extensions0={{ extensions }}"
 @set "extensions1=%extensions0:|= %"
 @set "extensions=%extensions1: undefined=%"
 
 :: Extract node type and name from vm.args
-@for /f "usebackq tokens=1-2" %%I in (`findstr /b "\-name \-sname" "%vm_args%"`) do @(
+@for /f "usebackq tokens=1-2" %%I in ('findstr /b "\-name \-sname" "%vm_args%"') do @(
   set node_type=%%I
   set node_name=%%J
 )
@@ -77,7 +78,7 @@
 )
 
 :: Extract cookie from vm.args
-@for /f "usebackq tokens=1-2" %%I in (`findstr /b \-setcookie "%vm_args%"`) do @(
+@for /f "usebackq tokens=1-2" %%I in ('findstr /b \-setcookie "%vm_args%"') do @(
   set cookie=%%J
 )
 
@@ -86,7 +87,7 @@
 
 :: Collect any additional VM args into erl_opts
 @setlocal EnableDelayedExpansion
-@for /f "usebackq tokens=1-2" %%I in (`findstr /r "^[^#]" "%vm_args%"`) do @(
+@for /f "usebackq tokens=1-2" %%I in ('findstr /r "^[^#]" "%vm_args%"') do @(
   if not "%%I" == "-name" (
     if not "%%I" == "-sname" (
       if not "%%I" == "-setcookie" (
@@ -361,25 +362,20 @@ set description=Erlang node %node_name%%hostname% in %rootdir%
 :: Failures are logged, but ignored.
 
 :: Create random dummy node name
-@set /a _rand_nr=%RANDOM%+100000
-@set dummy_name=dummy-%_rand_nr%
+@set /a "_rand_nr=%RANDOM%+100000"
+@set "dummy_name=dummy-%_rand_nr%"
 
-:: Run node, capture exitcode in temporary file and capture output in local var
-@for /f "delims=" %%i in ('"%erl%" -sname %dummy_name% -boot no_dot_erlang -noshell -s init stop 2^>^&1 ^& call echo %%^^ERRORLEVEL%%^>%TMP%\error.level') do @(
+:: Run node and capture output in local var
+@for /f "delims=" %%i in ('%erl% -sname %dummy_name% -boot no_dot_erlang -noshell -eval "halt()."') do @(
   set "dummy_node_output=%%i"
 )
 
-:: Read exit code from temporary file and delete that file
-@for /f "delims=" %%i in (%TMP%\error.level) do (set /a dummy_node_exitcode=%%i)
-@del %TMP%\error.level
-
-:: Print error log in case of a failed command execution
-@if %dummy_node_exitcode% neq 0 @(
-  @echo Creating .erlang.cookie failed: "%dummy_node_output%"
+:: Check for execution error
+@if "%dummy_node_output%" neq "" @(
+  echo Creating .erlang.cookie failed: "%dummy_node_output%"
 )
 
 :: Clear all local variables
 @set "dummy_node_output="
-@set "dummy_node_exitcode="
 
 @exit /b 0

--- a/priv/templates/extended_bin_windows
+++ b/priv/templates/extended_bin_windows
@@ -147,8 +147,7 @@
 )
 @set /a _rand_nr=%RANDOM%+100000
 @set dummy_name=dummy-%_rand_nr%
-@set dir_cmd="%erl%" -sname %dummy_name% -boot no_dot_erlang -noshell -eval "io:format(\"~s\", [filename:nativename(code:root_dir())])." -s init stop
-@for /f "delims=" %%i in ('%%dir_cmd%%') do @(
+@for /f "delims=" %%i in ('"%erl%" -sname %dummy_name% -boot no_dot_erlang -noshell -eval "io:format(\"~s\", [filename:nativename(code:root_dir())])." -s init stop') do @(
   set "erl_root=%%i"
 )
 @set "erts_dir=%erl_root%\erts-%erts_vsn%"

--- a/priv/templates/extended_bin_windows
+++ b/priv/templates/extended_bin_windows
@@ -145,9 +145,7 @@
 @for /f "delims=" %%i in ('where erl') do @(
   set "erl=%%i"
 )
-@set /a _rand_nr=%RANDOM%+100000
-@set dummy_name=dummy-%_rand_nr%
-@for /f "delims=" %%i in ('"%erl%" -sname %dummy_name% -boot no_dot_erlang -noshell -eval "io:format(\"~s\", [filename:nativename(code:root_dir())])." -s init stop') do @(
+@for /f "delims=" %%i in ('"%erl%" -boot no_dot_erlang -noshell -eval "io:format(\"~s\", [filename:nativename(code:root_dir())])." -s init stop') do @(
   set "erl_root=%%i"
 )
 @set "erts_dir=%erl_root%\erts-%erts_vsn%"
@@ -280,6 +278,7 @@ set description=Erlang node %node_name%%hostname% in %rootdir%
 
 :: Start the Windows service
 :start
+@call :ensure_dot_erlang_cookie
 @%erlsrv% start %service_name%
 @goto :eof
 
@@ -301,6 +300,7 @@ set description=Erlang node %node_name%%hostname% in %rootdir%
 
 :: Start a console
 :console
+@call :ensure_dot_erlang_cookie
 @set boot=-boot "%boot_script%" -boot_var RELEASE_DIR "%release_root_dir%"
 @start "%rel_name% console" %werl% %boot% %sys_config%  ^
        -args_file "%vm_args%"
@@ -353,3 +353,33 @@ set description=Erlang node %node_name%%hostname% in %rootdir%
 @if not "%ext_test_3%"=="x%extensions%" exit /b 0
 
 @exit /b 1
+
+:ensure_dot_erlang_cookie
+
+:: Run a dummy distributed erlang node just to ensure that %HOMEPATH%\.erlang.cookie exists.
+:: This action is best-effort and could fail because of the way the system is set up.
+:: Failures are logged, but ignored.
+
+:: Create random dummy node name
+@set /a _rand_nr=%RANDOM%+100000
+@set dummy_name=dummy-%_rand_nr%
+
+:: Run node, capture exitcode in temporary file and capture output in local var
+@for /f "delims=" %%i in ('"%erl%" -sname %dummy_name% -boot no_dot_erlang -noshell -s init stop 2^>^&1 ^& call echo %%^^ERRORLEVEL%%^>%TMP%\error.level') do @(
+  set "dummy_node_output=%%i"
+)
+
+:: Read exit code from temporary file and delete that file
+@for /f "delims=" %%i in (%TMP%\error.level) do (set /a dummy_node_exitcode=%%i)
+@del %TMP%\error.level
+
+:: Print error log in case of a failed command execution
+@if %dummy_node_exitcode% neq 0 @(
+  @echo Creating .erlang.cookie failed: "%dummy_node_output%"
+)
+
+:: Clear all local variables
+@set "dummy_node_output="
+@set "dummy_node_exitcode="
+
+@exit /b 0

--- a/priv/templates/extended_bin_windows
+++ b/priv/templates/extended_bin_windows
@@ -143,13 +143,13 @@
 :: Set the ERTS dir from erl
 :set_erts_dir_from_erl
 @for /f "delims=" %%i in ('where erl') do @(
-  set erl=%%i
+  set "erl=%%i"
 )
 @set /a _rand_nr=%RANDOM%+100000
 @set dummy_name=dummy-%_rand_nr%
 @set dir_cmd="%erl%" -sname %dummy_name% -boot no_dot_erlang -noshell -eval "io:format(\"~s\", [filename:nativename(code:root_dir())])." -s init stop
 @for /f "delims=" %%i in ('%%dir_cmd%%') do @(
-  set erl_root=%%i
+  set "erl_root=%%i"
 )
 @set "erts_dir=%erl_root%\erts-%erts_vsn%"
 @set "rootdir=%erl_root%"
@@ -159,13 +159,14 @@
 :find_sys_config
 @set "possible_sys=%rel_dir%\sys.config"
 @if exist "%possible_sys%" (
-  set sys_config=-config "%possible_sys%"
+  set "sys_config=-config \"%possible_sys%\""
 ) else (
   @if exist "%possible_sys%.orig" (
     ren "%possible_sys%.orig" sys.config
-    set sys_config=-config "%possible_sys%"
+    set "sys_config=-config \"%possible_sys%\""
   )
 )
+@goto :eof
 
 :: Find the vm.args file
 :find_vm_args

--- a/priv/templates/extended_bin_windows
+++ b/priv/templates/extended_bin_windows
@@ -145,7 +145,9 @@
 @for /f "delims=" %%i in ('where erl') do @(
   set erl=%%i
 )
-@set dir_cmd="%erl%" -sname dummy -boot no_dot_erlang -noshell -eval "io:format(\"~s\", [filename:nativename(code:root_dir())])." -s init stop
+@set /a _rand_nr=%RANDOM%+100000
+@set dummy_name=dummy-%_rand_nr%
+@set dir_cmd="%erl%" -sname %dummy_name% -boot no_dot_erlang -noshell -eval "io:format(\"~s\", [filename:nativename(code:root_dir())])." -s init stop
 @for /f "delims=" %%i in ('%%dir_cmd%%') do @(
   set erl_root=%%i
 )


### PR DESCRIPTION
Previously the all relx commands would try to create that file as part of the internal search for an ERTS path. This could lead to hard crashes as described in #696 if for some reason the Erlang node can't write that file. Therefore, this change moves the creation of the `.erlang.cookie` file just before executing the commands `start` or `console`, where the file actually matters. Moreover, the creation is optional and won't stop the procedure, just log an error if it occurred.

Fixes #696 