### PR TITLE
Fix parameter shift on win32 for extension commands

### DIFF
--- a/priv/templates/extended_bin_windows
+++ b/priv/templates/extended_bin_windows
@@ -324,8 +324,9 @@ set description=Erlang node %node_name%%hostname% in %rootdir%
 :: Run extension script
 :run_extension
 @if exist "%script_dir%\extensions\%1.cmd" (
-  shift
-  call "%script_dir%\extensions\%1.cmd" %*
+  set _extension_params=%*
+  call set _extension_params=%%_extension_params:*%1=%%
+  call "%script_dir%\extensions\%1.cmd" %%_extension_params%%
 )
 
 @goto :eof


### PR DESCRIPTION
Previously the shift would not be in effect because the `shift` command can't be used in combination with the `%*` parameter placeholder.