### PR TITLE
don't require a cookie in the start script

### DIFF
--- a/priv/templates/extended_bin
+++ b/priv/templates/extended_bin
@@ -136,17 +136,6 @@ find_erts_dir() {
     fi
 }
 
-ensure_dot_erlang_cookie() {
-  # Run a dummy distributed erlang node just to ensure that $HOME/.erlang.cookie exists.
-  # This action is best-effort and could fail because of the way the system is set up.
-  # Failures are logged, but ignored.
-  DUMMY_NAME="dummy-$(relx_gen_id)"
-  if ! output="$($ERTS_DIR/bin/erl -sname ${DUMMY_NAME} -boot no_dot_erlang -noshell -eval "halt()")"
-  then
-    echo "Creating .erlang.cookie failed: ${output}"
-  fi
-}
-
 # Get node pid
 relx_get_pid() {
     if output="$(relx_nodetool rpcterms os getpid)"
@@ -161,10 +150,19 @@ relx_get_pid() {
 
 relx_get_nodename() {
     id="longname$(relx_gen_id)-${NAME}"
-    "$BINDIR/erl" -boot start_clean \
-        -boot_var ERTS_LIB_DIR "$ERTS_LIB_DIR" \
-        -eval '[_,H]=re:split(atom_to_list(node()),"@",[unicode,{return,list}]), io:format("~s~n",[H]), halt()' \
-        -noshell ${NAME_TYPE} $id
+    if [ -z "$COOKIE" ]; then
+        "$BINDIR/erl" -boot start_clean \
+                      -boot_var ERTS_LIB_DIR "$ERTS_LIB_DIR" \
+                      -eval '[_,H]=re:split(atom_to_list(node()),"@",[unicode,{return,list}]), io:format("~s~n",[H]), halt()' \
+                      -noshell ${NAME_TYPE} $id
+    else
+        # running with setcookie prevents a ~/.erlang.cookie from being created
+        "$BINDIR/erl" -boot start_clean \
+                      -boot_var ERTS_LIB_DIR "$ERTS_LIB_DIR" \
+                      -eval '[_,H]=re:split(atom_to_list(node()),"@",[unicode,{return,list}]), io:format("~s~n",[H]), halt()' \
+                      -setcookie ${COOKIE} \
+                      -noshell ${NAME_TYPE} $id
+    fi
 }
 
 # Connect to a remote node
@@ -456,6 +454,21 @@ NAME_ARG=$(eval echo "${NAME_ARG}")
 NAME_TYPE="$(echo "$NAME_ARG" | awk '{print $1}')"
 NAME="$(echo "$NAME_ARG" | awk '{print $2}')"
 
+# Extract the target cookie
+# Do this before relx_get_nodename so we can use it and not create a ~/.erlang.cookie
+COOKIE_ARG="$(grep '^-setcookie' "$VMARGS_PATH" || true)"
+DEFAULT_COOKIE_FILE="$HOME/.erlang.cookie"
+if [ -z "$COOKIE_ARG" ]; then
+    if [ -f "$DEFAULT_COOKIE_FILE" ]; then
+        COOKIE="$(cat $DEFAULT_COOKIE_FILE)"
+    else
+        echo "No cookie is set or found. This limits the scripts functionality, installing, upgrading, rpc and getting a list of versions will not work."
+    fi
+else
+    # Extract cookie name from COOKIE_ARG
+    COOKIE="$(echo "$COOKIE_ARG" | awk '{print $2}')"
+fi
+
 # User can specify an sname without @hostname
 # This will fail when creating remote shell
 # So here we check for @ and add @hostname if missing
@@ -469,21 +482,6 @@ export NAME
 
 test -z "$PIPE_DIR" && PIPE_BASE_DIR='/tmp/erl_pipes/'
 PIPE_DIR="${PIPE_DIR:-/tmp/erl_pipes/$NAME/}"
-
-# Extract the target cookie
-COOKIE_ARG="$(grep '^-setcookie' "$VMARGS_PATH" || true)"
-DEFAULT_COOKIE_FILE="$HOME/.erlang.cookie"
-if [ -z "$COOKIE_ARG" ]; then
-    if [ -f "$DEFAULT_COOKIE_FILE" ]; then
-        COOKIE="$(cat $DEFAULT_COOKIE_FILE)"
-    else
-        echo "vm.args needs to have a -setcookie, or $DEFAULT_COOKIE_FILE (its permission must be 400) is required."
-        exit 1
-    fi
-else
-    # Extract cookie name from COOKIE_ARG
-    COOKIE="$(echo "$COOKIE_ARG" | awk '{print $2}')"
-fi
 
 VM_ARGS="$(grep -v -E '^#|^-name|^-sname|^-setcookie|^-heart|^-args_file' "$VMARGS_PATH" | xargs | sed -e 's/ / /g')"
 
@@ -520,8 +518,6 @@ case "$1" in
 
         # Make sure log directory exists
         mkdir -p "$RUNNER_LOG_DIR"
-
-        ensure_dot_erlang_cookie
 
         relx_run_hooks "$PRE_START_HOOKS"
         "$BINDIR/run_erl" -daemon "$PIPE_DIR" "$RUNNER_LOG_DIR" \
@@ -692,8 +688,6 @@ case "$1" in
             -args_file "$VMARGS_PATH" \
             -pa ${__code_paths} -- "$@"
         echo "Root: $ROOTDIR"
-
-        ensure_dot_erlang_cookie
 
         # Log the startup
         echo "$RELEASE_ROOT_DIR"

--- a/priv/templates/extended_bin_windows
+++ b/priv/templates/extended_bin_windows
@@ -279,7 +279,6 @@ set description=Erlang node %node_name%%hostname% in %rootdir%
 
 :: Start the Windows service
 :start
-@call :ensure_dot_erlang_cookie
 @%erlsrv% start %service_name%
 @goto :eof
 
@@ -301,7 +300,6 @@ set description=Erlang node %node_name%%hostname% in %rootdir%
 
 :: Start a console
 :console
-@call :ensure_dot_erlang_cookie
 @set boot=-boot "%boot_script%" -boot_var RELEASE_DIR "%release_root_dir%"
 @start "%rel_name% console" %werl% %boot% %sys_config%  ^
        -args_file "%vm_args%"
@@ -355,27 +353,3 @@ set description=Erlang node %node_name%%hostname% in %rootdir%
 
 @exit /b 1
 
-:ensure_dot_erlang_cookie
-
-:: Run a dummy distributed erlang node just to ensure that %HOMEPATH%\.erlang.cookie exists.
-:: This action is best-effort and could fail because of the way the system is set up.
-:: Failures are logged, but ignored.
-
-:: Create random dummy node name
-@set /a "_rand_nr=%RANDOM%+100000"
-@set "dummy_name=dummy-%_rand_nr%"
-
-:: Run node and capture output in local var
-@for /f "delims=" %%i in ('%erl% -sname %dummy_name% -boot no_dot_erlang -noshell -eval "halt()."') do @(
-  set "dummy_node_output=%%i"
-)
-
-:: Check for execution error
-@if "%dummy_node_output%" neq "" @(
-  echo Creating .erlang.cookie failed: "%dummy_node_output%"
-)
-
-:: Clear all local variables
-@set "dummy_node_output="
-
-@exit /b 0


### PR DESCRIPTION
@tolbrino @uwiger

I think I finally understand what the root issue was. Is it true that you were seeing the node refuse to start because no cookie was set but that this error was from the start script itself?

This change makes it so the start script doesn't enforce the existence of a cookie and allows it to be created by Erlang on startup. 

Though, I don't believe @tolbrino 's latest changes would have worked for you since the creation ran after that check in the script, so if that was working then I may be going the wrong way with this.