### PR TITLE
Add ERTS_LIB_DIR applications path to code server in console_clean

### DIFF
--- a/priv/templates/extended_bin
+++ b/priv/templates/extended_bin
@@ -218,7 +218,15 @@ relx_escript() {
 relx_get_code_paths() {
     code="{ok, [{release,_,_,Apps}]} = file:consult(\"$REL_DIR/$REL_NAME.rel\"),"\
 "lists:foreach(fun(A) ->"\
-"   io:fwrite(\"$ROOTDIR/lib/~p-~s/ebin \", [element(1, A), element(2, A)]) "\
+"   EbinDir = io_lib:format(\"~p-~s/ebin \", [element(1, A), element(2, A)]),"\
+"   RelLibPath = \"$ROOTDIR/lib/\" ++ EbinDir,"\
+"   ErtsLibPath = \"$ERTS_LIB_DIR/\" ++ EbinDir,"\
+"   case filelib:is_dir(RelLibPath) of"\
+"      true ->"\
+"         io:fwrite(RelLibPath);"\
+"      _ ->"\
+"         io:fwrite(ErtsLibPath)"\
+"   end "\
 "end, Apps),"\
 "halt()."
 


### PR DESCRIPTION
When starting the release with console_clean, the applications are assumed to be in ROOTDIR/lib, and this may not be the case with applications included from the ERTS if the ERTS itself is not included.

This PR makes console_clean check the ERTS_LIB_DIR for the included applications too to add their paths to the code server.
