### PR TITLE
Fix "'findstr' is not recognized as ..."

### DIFF
--- a/priv/templates/extended_bin_windows
+++ b/priv/templates/extended_bin_windows
@@ -1,3 +1,4 @@
+@echo off
 :: This batch file handles managing an Erlang node as a Windows service.
 ::
 :: Commands provided:
@@ -19,6 +20,9 @@
 @set rel_vsn={{ rel_vsn }}
 @set erts_vsn={{ erts_vsn }}
 @set erl_opts={{ erl_opts }}
+
+:: Make sure `findstr` is accessible
+@set PATH=%PATH%;%SystemRoot%\System32
 
 :: Discover the release root directory from the directory
 :: of this script


### PR DESCRIPTION
Make sure findstr is discoverable

In certain cases `findstr` could not be found in path (ie command is executed by an external process which does not properly import env).

For instance bundling an app with https://github.com/achadwick/styrene + relx (ref https://github.com/aeternity/relx/pull/4 )

Styrene overrides the default path variable removing the `Windows\System32` entry which makes findstr unavailable when script is executed from the launcher aeternity.exe resulting in:

```
'findstr' is not recognized as an internal or external command,
operable program or batch file.
'findstr' is not recognized as an internal or external command,
operable program or batch file.
'findstr' is not recognized as an internal or external command,
operable program or batch file.
test.cmd exited with status 0.
Press return to close this window.
```
rel: https://github.com/achadwick/styrene/issues/23

Patch just adds `%SystemRoot%\System32` in `%PATH%` + turn off command echo (some commands miss the `@`)

Alternative fix could be to replace all occurrences of `findstr` with `%SystemRoot%\System32\findstr`
