### PR TITLE
quick fix for overlay that copies to top level of release

### DIFF
--- a/src/rlx_prv_archive.erl
+++ b/src/rlx_prv_archive.erl
@@ -158,6 +158,8 @@ overlay_files(OverlayVars, Overlay, OutputDir) ->
 
 to({link, _, To}) ->
     To;
+to({copy, From, "."}) ->
+    filename:basename(From);
 to({copy, _, To}) ->
     To;
 to({mkdir, To}) ->


### PR DESCRIPTION
Fix for #674 

I need to do some other improvements to overlays but this at least fixes the existing bug.