### PR TITLE
Fix path variables quoting for Windows

### DIFF
--- a/priv/templates/extended_bin_windows
+++ b/priv/templates/extended_bin_windows
@@ -320,7 +320,7 @@ set description=Erlang node %node_name%%hostname% in %rootdir%
 
 :: Ping the running node
 :ping
-@%escript% %nodetool% ping %node_type% "%node_name%%hostname%" -setcookie "%cookie%"
+@%escript% %nodetool% ping %node_type% %node_name%%hostname% -setcookie %cookie%
 @goto :eof
 
 :: List installed Erlang services
@@ -332,7 +332,7 @@ set description=Erlang node %node_name%%hostname% in %rootdir%
 :attach
 @set boot=-boot "%clean_boot_script%" -boot_var RELEASE_DIR "%release_root_dir%"
 @start "%node_name% attach" %werl% %boot% ^
-       -remsh "%node_name%%hostname%" %node_type% console -setcookie "%cookie%"
+       -remsh %node_name%%hostname% %node_type% console -setcookie %cookie%
 @goto :eof
 
 :: Run extension script

--- a/priv/templates/extended_bin_windows
+++ b/priv/templates/extended_bin_windows
@@ -41,12 +41,12 @@
 @set vm_args=%rel_dir%\vm.args
 @set progname=erl.exe
 @set clean_boot_script=%release_root_dir%\bin\start_clean
-@set "erlsrv=%bindir%\erlsrv.exe"
-@set "epmd=%bindir%\epmd.exe"
-@set "escript=%bindir%\escript.exe"
-@set "werl=%bindir%\werl.exe"
-@set "erl=%bindir%\erl.exe"
-@set "nodetool=%release_root_dir%\bin\nodetool"
+@set erlsrv="%bindir%\erlsrv.exe"
+@set epmd="%bindir%\epmd.exe"
+@set escript="%bindir%\escript.exe"
+@set werl="%bindir%\werl.exe"
+@set erl="%bindir%\erl.exe"
+@set nodetool="%release_root_dir%\bin\nodetool"
 @set "extensions0={{ extensions }}"
 @set "extensions1=%extensions0:|= %"
 @set "extensions=%extensions1: undefined=%"
@@ -159,7 +159,7 @@
 @for /f "delims=" %%i in ('where erl') do @(
   set "erl=%%i"
 )
-@for /f "delims=" %%i in ('"%erl%" -boot no_dot_erlang -noshell -eval "io:format(\"~s\", [filename:nativename(code:root_dir())])." -s init stop') do @(
+@for /f "delims=" %%i in ('%erl% -boot no_dot_erlang -noshell -eval "io:format(\"~s\", [filename:nativename(code:root_dir())])." -s init stop') do @(
   set "erl_root=%%i"
 )
 @set "erts_dir=%erl_root%\erts-%erts_vsn%"
@@ -332,7 +332,7 @@ set description=Erlang node %node_name%%hostname% in %rootdir%
 :attach
 @set boot=-boot "%clean_boot_script%" -boot_var RELEASE_DIR "%release_root_dir%"
 @start "%node_name% attach" %werl% %boot% ^
-       -remsh %node_name%%hostname% %node_type% console -setcookie %cookie%
+       -remsh "%node_name%%hostname%" %node_type% console -setcookie "%cookie%"
 @goto :eof
 
 :: Run extension script


### PR DESCRIPTION
Release will not properly work if installation (and/or bindir) includes spaces.
For instance if the release is installed in `C:\Program Files` and werl.exe is bundled. 

Many commands are executed without quotes thus as a side-effect, path with spaces will be threated as separate command arguments (instead of a single path argument). ie `C:\Program Files\werl.exe` will be threated from the shell as 2 arguments: `C:\Program` and `Files\werl.exe`. 

Background:
Quoting in Windows shell does not work as in other systems. When setting a variable if the quotes are after `=` they will be included in the value if both varname and value are surrounded by quotes this will escape the whole assignment so the command is properly executed (as `set` could have some flags and options in addition to the value).
so `set "var=foo /d"` will result in a variable `%var%` with a value `foo /d`
while `set var="foo /d"` will result in a variable `%var%` with a value `"foo /d"`
at last (without quotes)
`set var=foo /d` will result to `set /d var=foo` which will probably not what is expected (thus set commands are quoted)

Similarly unquoted variables with spaces (in this case a windows path) will be threated as arguments if they include spaces. However we can avoid quoting every variable if we use the trick above that puts the quotes in the value itself. 

Fixes #731 