### PR TITLE
always use cirrus compute credits

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,5 +1,5 @@
 test_task:
-  use_compute_credits: $CIRRUS_USER_COLLABORATOR == 'true'
+  use_compute_credits: true
   container:
     matrix:
       - image: erlang:22

--- a/test/rlx_archive_SUITE.erl
+++ b/test/rlx_archive_SUITE.erl
@@ -18,7 +18,7 @@
 -include_lib("kernel/include/file.hrl").
 
 suite() ->
-    [{timetrap, {seconds, 120}}].
+    [].
 
 init_per_suite(Config) ->
     Config.

--- a/test/rlx_command_SUITE.erl
+++ b/test/rlx_command_SUITE.erl
@@ -34,7 +34,7 @@
 -include_lib("eunit/include/eunit.hrl").
 
 suite() ->
-    [{timetrap,{seconds,120}}].
+    [].
 
 init_per_suite(Config) ->
     Config.

--- a/test/rlx_discover_SUITE.erl
+++ b/test/rlx_discover_SUITE.erl
@@ -34,7 +34,7 @@
 -include_lib("eunit/include/eunit.hrl").
 
 suite() ->
-    [{timetrap,{seconds,120}}].
+    [].
 
 init_per_suite(Config) ->
     Config.

--- a/test/rlx_eunit_SUITE.erl
+++ b/test/rlx_eunit_SUITE.erl
@@ -30,7 +30,7 @@
 -include_lib("eunit/include/eunit.hrl").
 
 suite() ->
-    [{timetrap,{seconds,120}}].
+    [].
 
 init_per_suite(Config) ->
     Config.

--- a/test/rlx_extended_bin_SUITE.erl
+++ b/test/rlx_extended_bin_SUITE.erl
@@ -66,7 +66,7 @@
 -define(SLEEP_TIME, 2500).
 
 suite() ->
-    [{timetrap,{seconds,300}}].
+    [].
 
 init_per_suite(Config) ->
     Config.

--- a/test/rlx_release_SUITE.erl
+++ b/test/rlx_release_SUITE.erl
@@ -67,7 +67,7 @@
 -include_lib("kernel/include/file.hrl").
 
 suite() ->
-    [{timetrap,{seconds,120}}].
+    [].
 
 init_per_suite(Config) ->
     Config.


### PR DESCRIPTION
Always use the compute credits for cirrus so that PRs from non-collaborators don't timeout.