### PR TITLE
Implement systemd-like support for hook directories

### DIFF
--- a/priv/templates/extended_bin
+++ b/priv/templates/extended_bin
@@ -316,6 +316,21 @@ relx_disable_hooks() {
     PRE_INSTALL_UPGRADE_HOOKS=""
     POST_INSTALL_UPGRADE_HOOKS=""
     STATUS_HOOK=""
+
+    RELX_HOOKS_DISABLED=1
+}
+
+relx_enable_hooks() {
+    [ ${RELX_HOOKS_DISABLED:-0} -ne 0 ] && return
+    # Strip file extension, and add ".d" suffix
+    HOOKS_DIR=${SCRIPT%%.*}.d
+    [ -z $PRE_START_HOOKS             ] && for f in "$HOOKS_DIR"/pre-start-* ;    do [ -f "$f" ] && . "$f"; done
+    [ -z $POST_START_HOOKS            ] && for f in "$HOOKS_DIR"/post-start-* ;   do [ -f "$f" ] && . "$f"; done
+    [ -z $PRE_STOP_HOOKS              ] && for f in "$HOOKS_DIR"/pre-stop-* ;     do [ -f "$f" ] && . "$f"; done
+    [ -z $POST_STOP_HOOKS             ] && for f in "$HOOKS_DIR"/post-stop-* ;    do [ -f "$f" ] && . "$f"; done
+    [ -z $PRE_INSTALL_UPGRADE_HOOKS   ] && for f in "$HOOKS_DIR"/pre-install-* ;  do [ -f "$f" ] && . "$f"; done
+    [ -z $POST_INSTALL_UPGRADE_HOOKS  ] && for f in "$HOOKS_DIR"/post-install-* ; do [ -f "$f" ] && . "$f"; done
+    return 0
 }
 
 relx_is_extension() {
@@ -504,6 +519,10 @@ test -z "$PIPE_DIR" && PIPE_BASE_DIR='/tmp/erl_pipes/'
 PIPE_DIR="${PIPE_DIR:-/tmp/erl_pipes/$NAME/}"
 
 cd "$ROOTDIR"
+
+# Source hooks if there is no override and they are not disabled by
+# --relx-disable-hooks
+relx_enable_hooks
 
 # Check the first argument for instructions
 case "$1" in


### PR DESCRIPTION
1. A new variation of the `extended_start_script_hooks` option
is added that can define a source directory containing hook
scripts: `{directory, HookScriptsDir::string()}`. When defined,
the scripts will be copied to a sub-folder in the release at
the level of the extended start script.  That subfolder
will have the same name as the basename of the extended start
script (without the release version number and extension), and
will have a `.d` suffix.

2. That subdirectory can contain `pre-/post-` `start/stop/install`
scripts with by saving them in the startup script's release directory
that has a `.d` suffix. So, if the extended script's name is `myapp.sh`,
then the hook directory can be:
```
bin
  +-- myapp.sh   <-- Extended start script
  +-- myapp.d
    +-- pre-start.NN
    +-- post-start.NN
    +-- pre-stop.NN
    +-- post-stop.NN
    +-- pre-install.NN
    +-- post-install.NN
```
The hook extension files can have any suffix (such as `.NN` shown above).
The files in this directory will be sourced only if the corresponding
`PRE_*` or `POST_*` variables (populated by respective `pre_*` and `post_*`
hook configuration options) don't contain script names that override
this behavior.