### PR TITLE
Fix undesired start of epmd when calling relx_get_nodename

### DIFF
--- a/priv/templates/extended_bin
+++ b/priv/templates/extended_bin
@@ -154,6 +154,7 @@ relx_get_nodename() {
                       -mode interactive \
                       -boot_var ERTS_LIB_DIR "$ERTS_LIB_DIR" \
                       -eval '[_,H]=re:split(atom_to_list(node()),"@",[unicode,{return,list}]), io:format("~s~n",[H]), halt()' \
+                      ${START_EPMD} \
                       -noshell ${NAME_TYPE} $id
     else
         # running with setcookie prevents a ~/.erlang.cookie from being created
@@ -162,6 +163,7 @@ relx_get_nodename() {
                       -boot_var ERTS_LIB_DIR "$ERTS_LIB_DIR" \
                       -eval '[_,H]=re:split(atom_to_list(node()),"@",[unicode,{return,list}]), io:format("~s~n",[H]), halt()' \
                       -setcookie ${COOKIE} \
+                      ${START_EPMD} \
                       -noshell ${NAME_TYPE} $id
     fi
 }


### PR DESCRIPTION
I don't have epmd started on my machine and I don't want epmd to start from a release.
If you set `-start_epmd false` in your `vm.args` I expect epmd not to start, like this:
```
/tmp/athc # ./bin/athcontroller console
Protocol 'inet_tcp': register/listen error: /tmp/athc #
```
Instead, because of an earlier call to `relx_get_nodename` here:
https://github.com/erlware/relx/blob/f6bdffcd9bff0b62f3b7fd7bbf3db034f05fbd66/priv/templates/extended_bin#L497
the result is an unwanted start of epmd.
The solution I propose is to pass `${START_EPMD}` to `erl` inside `relx_get_nodename` so if `-start_epmd` is set to `false` we do not start epmd, rather we exit. Of course if you already have an instance of epmd running this works anyway.