### PR TITLE
Correctly render redefined variable

### DIFF
--- a/src/rlx_prv_overlay.erl
+++ b/src/rlx_prv_overlay.erl
@@ -187,9 +187,11 @@ merge_overlay_vars(State, FileNames) ->
                                 %% to the current one being read
                                 OverlayRelativeRoot = filename:dirname(FileName),
                                 NewTerms = check_overlay_inclusion(State, OverlayRelativeRoot, Terms),
+                                %% Remove already defined variables from Acc,
+                                %% append NewTerms, preserving order
                                 lists:foldl(fun(NewTerm, A) ->
-                                                    lists:keystore(element(1, NewTerm), 1, A, NewTerm)
-                                            end, Acc, NewTerms);
+                                                    lists:keydelete(element(1, NewTerm), 1, A)
+                                            end, Acc, NewTerms) ++ NewTerms;
                             {error, Reason} ->
                                 ec_cmd_log:warn(rlx_state:log(State),
                                                 format_error({unable_to_read_varsfile, FileName, Reason})),

--- a/test/rlx_release_SUITE.erl
+++ b/test/rlx_release_SUITE.erl
@@ -781,14 +781,18 @@ overlay_release(Config) ->
                     goal_app_2]}]),
 
     VarsFile1 = filename:join([LibDir1, "vars1.config"]),
+    %% tpl_var is defined in vars1, but redifined in vars2 using template.
     rlx_test_utils:write_config(VarsFile1, [{yahoo, "yahoo"},
                                             {yahoo2, [{foo, "bar"}]},
                                             {foo_yahoo, "foo_{{yahoo}}"},
-                                            {foo_dir, "foodir"}]),
+                                            {foo_dir, "foodir"},
+                                            {tpl_var, "defined in vars1"}]),
 
     VarsFile2 = filename:join([LibDir1, "vars2.config"]),
     rlx_test_utils:write_config(VarsFile2, [{google, "yahoo"},
                                             {yahoo2, "foo"},
+                                            {tpl_arg, "a template value"},
+                                            {tpl_var, "Redefined in vars2 with {{tpl_arg}}"},
                                             OverlayVars3]),
 
     VarsFile3 = filename:join([LibDir1, "vars3.config"]),
@@ -857,7 +861,11 @@ overlay_release(Config) ->
     ?assertEqual("val1",
                  proplists:get_value(prop1, TemplateData)),
     ?assertEqual(2,
-                 proplists:get_value(prop2, TemplateData)).
+                 proplists:get_value(prop2, TemplateData)),
+    %% This should be rendered correctly based on VarsFile2 file, regardless
+    %% of tpl_var defined in VarsFile1 or not.
+    ?assertEqual("Redefined in vars2 with a template value",
+                 proplists:get_value(tpl_var, TemplateData)).
 
 make_goalless_release(Config) ->
     LibDir1 = proplists:get_value(lib1, Config),

--- a/test/rlx_test_utils.erl
+++ b/test/rlx_test_utils.erl
@@ -185,7 +185,8 @@ test_template_contents() ->
         "{foo_yahoo, \"{{foo_yahoo}}\"}.\n"
         "{google, \"{{google}}\"}.\n"
         "{prop1, \"{{prop1}}\"}.\n"
-        "{prop2, {{prop2}}}.\n".
+        "{prop2, {{prop2}}}.\n"
+        "{tpl_var, \"{{tpl_var}}\"}.\n".
 
 escript_contents() ->
     "#!/usr/bin/env escript\n"


### PR DESCRIPTION
Rendering of variables behaves differently for already defined
variables.
Values of such variables are rendered in the wrong order,
ignoring any variables above from the same file.

Failing test without the fix:

```erlang
./rebar3/rebar3 ct --suite rlx_release_SUITE --case overlay_release   
===> Verifying dependencies...                                                                     
===> Compiling relx                                                                   
===> Running Common Test suites...                                                                     
%%% rlx_release_SUITE:                                                                                                                                                                                    
%%% rlx_release_SUITE ==> overlay_release: FAILED                                                  
%%% rlx_release_SUITE ==>                                                                                                                                                                                 
Failure/Error: ?assertEqual([82,101,100,101,102,105,110,101,100,32,105,110,32,118,97,114,115,50,32,119,105,116,104,32,97,32,116,101,109,112,108,97,116,101,32,118,97,108,117,101], proplists : get_value (
 tpl_var , TemplateData ))                                                                               
  expected: "Redefined in vars2 with a template value"                                                                                                                                                    
       got: "Redefined in vars2 with "                                                                              
      line: 866 
```