### PR TITLE
Allow for API callers to define arbitrary overlay variables

### DIFF
--- a/src/rlx_cmd_args.erl
+++ b/src/rlx_cmd_args.erl
@@ -298,6 +298,9 @@ create(add_providers, Opts) ->
 create(providers, Opts) ->
     Providers = proplists:get_value(providers, Opts, []),
     {providers, Providers};
+create(api_caller_overlays, Opts) ->
+    ApiCallerOverlays = proplists:get_value(api_caller_overlays, Opts, []),
+    {api_caller_overlays, ApiCallerOverlays};
 create(_, _) ->
     [].
 

--- a/src/rlx_prv_overlay.erl
+++ b/src/rlx_prv_overlay.erl
@@ -152,10 +152,15 @@ get_overlay_vars_from_file(State, OverlayVars) ->
 -spec read_overlay_vars(rlx_state:t(), proplists:proplist(), [file:name()]) ->
                                proplists:proplist() | relx:error().
 read_overlay_vars(State, OverlayVars, FileNames) ->
+    ApiCallerVars = rlx_state:api_caller_overlays(State),
     Terms = merge_overlay_vars(State, FileNames),
-    case render_overlay_vars(OverlayVars, Terms, []) of
+    case render_overlay_vars(OverlayVars ++ ApiCallerVars, Terms, []) of
         {ok, NewTerms} ->
-            OverlayVars ++ NewTerms;
+            % We place `ApiCallerVars' at the end on purpose; their
+            % definitions should be overwrittenable by both internal
+            % and rendered vars, as not to change behaviour in
+            % setups preceding the support for API caller overlays.
+            OverlayVars ++ NewTerms ++ ApiCallerVars;
         Error ->
             Error
     end.
@@ -273,8 +278,7 @@ generate_state_vars(State) ->
                                erlang:atom_to_list(Name1);
                            {Name1, Vsn1} ->
                                erlang:atom_to_list(Name1) ++ "-" ++ Vsn1
-                       end}
-     | rlx_state:api_caller_overlays(State)].
+                       end}].
 
 -spec do_overlay(rlx_state:t(), list(), proplists:proplist()) ->
                                    {ok, rlx_state:t()} | relx:error().

--- a/src/rlx_prv_overlay.erl
+++ b/src/rlx_prv_overlay.erl
@@ -273,7 +273,8 @@ generate_state_vars(State) ->
                                erlang:atom_to_list(Name1);
                            {Name1, Vsn1} ->
                                erlang:atom_to_list(Name1) ++ "-" ++ Vsn1
-                       end}].
+                       end}
+     | rlx_state:api_caller_overlays(State)].
 
 -spec do_overlay(rlx_state:t(), list(), proplists:proplist()) ->
                                    {ok, rlx_state:t()} | relx:error().

--- a/src/rlx_state.erl
+++ b/src/rlx_state.erl
@@ -44,6 +44,7 @@
          goals/2,
          config_file/1,
          config_file/2,
+         api_caller_overlays/1,
          cli_args/1,
          cli_args/2,
          providers/1,
@@ -104,6 +105,7 @@
                   output_dir :: file:name(),
                   lib_dirs=[] :: [file:name()],
                   config_file=[] :: file:filename() | undefined,
+                  api_caller_overlays=[] :: [{atom(),string()}],
                   cli_args=[] :: proplists:proplist(),
                   goals=[] :: [rlx_depsolver:raw_constraint()],
                   providers=[] :: [providers:t()],
@@ -160,8 +162,10 @@ new(Config, CommandLineConfig, Targets)
     Log = proplists:get_value(
             log, CommandLineConfig,
             ec_cmd_log:new(error, Caller, rlx_util:intensity())),
+    ApiCallerOverlays = proplists:get_value(api_caller_overlays, CommandLineConfig, []),
     State0 = #state_t{log=Log,
                       config_file=Config,
+                      api_caller_overlays=ApiCallerOverlays,
                       cli_args=CommandLineConfig,
                       actions=Targets,
                       caller=Caller,
@@ -269,6 +273,10 @@ config_file(#state_t{config_file=ConfigFiles}) ->
 -spec config_file(t(), file:filename() | proplists:proplist() | undefined) -> t().
 config_file(State, ConfigFiles) ->
     State#state_t{config_file=ConfigFiles}.
+
+-spec api_caller_overlays(t()) -> [{atom(),string()}].
+api_caller_overlays(#state_t{api_caller_overlays = ApiCallerOverlays}) ->
+    ApiCallerOverlays.
 
 -spec cli_args(t()) -> proplists:proplist().
 cli_args(#state_t{cli_args=CliArgs}) ->

--- a/src/rlx_state.erl
+++ b/src/rlx_state.erl
@@ -105,7 +105,7 @@
                   output_dir :: file:name(),
                   lib_dirs=[] :: [file:name()],
                   config_file=[] :: file:filename() | undefined,
-                  api_caller_overlays=[] :: [{atom(),string()}],
+                  api_caller_overlays=[] :: [{atom(),term()}],
                   cli_args=[] :: proplists:proplist(),
                   goals=[] :: [rlx_depsolver:raw_constraint()],
                   providers=[] :: [providers:t()],
@@ -274,7 +274,7 @@ config_file(#state_t{config_file=ConfigFiles}) ->
 config_file(State, ConfigFiles) ->
     State#state_t{config_file=ConfigFiles}.
 
--spec api_caller_overlays(t()) -> [{atom(),string()}].
+-spec api_caller_overlays(t()) -> [{atom(),term()}].
 api_caller_overlays(#state_t{api_caller_overlays = ApiCallerOverlays}) ->
     ApiCallerOverlays.
 

--- a/test/rlx_test_utils.erl
+++ b/test/rlx_test_utils.erl
@@ -186,7 +186,8 @@ test_template_contents() ->
         "{google, \"{{google}}\"}.\n"
         "{prop1, \"{{prop1}}\"}.\n"
         "{prop2, {{prop2}}}.\n"
-        "{tpl_var, \"{{tpl_var}}\"}.\n".
+        "{tpl_var, \"{{tpl_var}}\"}.\n"
+        "{profile_string_value, \"{{profile_string_value}}\"}.\n".
 
 escript_contents() ->
     "#!/usr/bin/env escript\n"

--- a/test/rlx_test_utils.erl
+++ b/test/rlx_test_utils.erl
@@ -187,7 +187,7 @@ test_template_contents() ->
         "{prop1, \"{{prop1}}\"}.\n"
         "{prop2, {{prop2}}}.\n"
         "{tpl_var, \"{{tpl_var}}\"}.\n"
-        "{profile_string_value, \"{{profile_string_value}}\"}.\n".
+        "{api_caller_var, \"{{api_caller_var}}\"}.\n".
 
 escript_contents() ->
     "#!/usr/bin/env escript\n"


### PR DESCRIPTION
This PR proposes adding support for overlay variables arbitrarily defined by API callers, as a basis to solve rebar3 [issue 1254](https://github.com/erlang/rebar3/issues/1254).