### PR TITLE
add new relx env_file option to set default env vars

### DIFF
--- a/priv/templates/extended_bin
+++ b/priv/templates/extended_bin
@@ -378,6 +378,12 @@ process_internal_args() {
     done
 }
 
+ENV_PATH=$(add_path env)
+
+if [ -f "$ENV_PATH" ]; then
+    eval $(cat $ENV_PATH)
+fi
+
 # process internal arguments
 process_internal_args $@
 

--- a/src/rlx_config.erl
+++ b/src/rlx_config.erl
@@ -243,6 +243,8 @@ load_terms({release, {RelName, Vsn}, Applications, Config}, {ok, State0}) ->
             Release2 = rlx_release:config(Release1, Config),
             {ok, rlx_state:add_configured_release(State0, Release2)}
         end;
+load_terms({env_file, EnvFile}, {ok, State}) ->
+    {ok, rlx_state:env_file(State, filename:absname(EnvFile))};
 load_terms({vm_args, false}, {ok, State}) ->
     {ok, rlx_state:vm_args(State, false)};
 load_terms({vm_args, VmArgs}, {ok, State}) ->

--- a/src/rlx_state.erl
+++ b/src/rlx_state.erl
@@ -53,6 +53,8 @@
          prepend_hook/3,
          append_hook/3,
          hooks/2,
+         env_file/1,
+         env_file/2,
          vm_args/1,
          vm_args/2,
          vm_args_src/1,
@@ -111,6 +113,7 @@
                   providers=[] :: [providers:t()],
                   available_apps=[] :: [rlx_app_info:t()],
                   default_configured_release :: {rlx_release:name() | undefined, rlx_release:vsn() |undefined} | undefined,
+                  env_file :: file:filename() | undefined,
                   vm_args :: file:filename() | false | undefined,
                   vm_args_src :: file:filename() | undefined,
                   sys_config :: file:filename() | false | undefined,
@@ -289,6 +292,14 @@ cli_args(State, CliArgs) ->
 -spec providers(t()) -> [providers:t()].
 providers(#state_t{providers=Providers}) ->
     Providers.
+
+-spec env_file(t()) -> file:filename() | undefined.
+env_file(#state_t{env_file=EnvFile}) ->
+    EnvFile.
+
+-spec env_file(t(), undefined | file:filename()) -> t().
+env_file(State, EnvFile) ->
+    State#state_t{env_file=EnvFile}.
 
 -spec vm_args(t()) -> file:filename() | false | undefined.
 vm_args(#state_t{vm_args=VmArgs}) ->


### PR DESCRIPTION
add new option `env_file` where default value for env vars are specified

example:
```
{env_file, "config/default.env"}
```
where `default.env` contains default values to export, eg:

```
export VM_COOKIE="${VM_COOKIE:-secret}"
export VM_START_EPMD="${VM_START_EPMD:-false}"
```

will copy `default.env` to `releases/VSN/env`
the extended script at runtime will read the file and set the vars

see #717 
see #759
