### PR TITLE
rlx_prv_assembler:copy_dir -- always copy recursively

### DIFF
--- a/src/rlx_prv_assembler.erl
+++ b/src/rlx_prv_assembler.erl
@@ -355,7 +355,7 @@ copy_dir(SourceDir, TargetDir, ExcludeFiles) ->
     lists:foreach(fun(F) ->
                     ok = ec_file:copy(F,
                                       filename:join([TargetDir,
-                                                     filename:basename(F)]), [{file_info, [mode, time]}])
+                                                     filename:basename(F)]), [recursive, {file_info, [mode, time]}])
                   end, SourceFiles -- ExcludeFiles).
 
 create_release_info(State0, Release0, OutputDir) ->

--- a/test/rlx_release_SUITE.erl
+++ b/test/rlx_release_SUITE.erl
@@ -1617,7 +1617,11 @@ make_exclude_modules_release(Config) ->
     LibDir1 = proplists:get_value(lib1, Config),
 
     rlx_test_utils:create_app(LibDir1, "goal_app_1", "0.0.1", [stdlib,kernel, non_goal_1], []),
-    rlx_test_utils:create_app(LibDir1, "non_goal_1", "0.0.1", [stdlib,kernel], []),
+    {ok, NonGoalAppInfo} = rlx_test_utils:create_app(LibDir1, "non_goal_1", "0.0.1", [stdlib,kernel], []),
+
+    NonGoalAppDir = rlx_app_info:dir(NonGoalAppInfo),
+    FooFilename = filename:join([NonGoalAppDir, "priv/subdir/foo.txt"]),
+    rlx_test_utils:write_config(FooFilename, []),
 
     ConfigFile = filename:join([LibDir1, "relx.config"]),
     rlx_test_utils:write_config(ConfigFile,


### PR DESCRIPTION
It is very possible for e.g. priv to have subdirs of its own.