### PR TITLE
make each configuration element a state record field

### DIFF
--- a/src/relx.erl
+++ b/src/relx.erl
@@ -142,7 +142,7 @@ format_error({no_release_name, Vsn}) ->
     io_lib:format("A target release version was specified (~s) but no name", [Vsn]);
 format_error({invalid_release_info, Info}) ->
     io_lib:format("Target release information is in an invalid format ~p", [Info]);
-format_error(multiple_release_names) ->
+format_error({multiple_release_names, _, _}) ->
     "Must specify the name of the release to build when there are multiple releases in the config";
 format_error(no_releases_in_system) ->
     "No releases have been specified in the system!";
@@ -195,9 +195,9 @@ pick_release_version(RelName, State) ->
 release_sort({{RelName, RelVsnA}, _},
              {{RelName, RelVsnB}, _}) ->
     rlx_util:parsed_vsn_lte(rlx_util:parse_vsn(RelVsnB), rlx_util:parse_vsn(RelVsnA));
-release_sort({{_RelA, _}, _}, {{_RelB, _}, _}) ->
+release_sort({{RelA, _}, _}, {{RelB, _}, _}) ->
     %% The release names are different. When the releases are named differently
     %% we can not just take the lastest version. You *must* provide a default
     %% release name at least. So we throw an error here that the top can catch
     %% and return
-    error(?RLX_ERROR(multiple_release_names)).
+    error(?RLX_ERROR({multiple_release_names, RelA, RelB})).

--- a/src/rlx_assemble.erl
+++ b/src/rlx_assemble.erl
@@ -707,8 +707,11 @@ create_RELEASES(State, OutputDir, ReleaseFile) ->
                                                      []) of
                     ok ->
                         ok;
-                    {error, Reason} ->
-                        erlang:error(?RLX_ERROR({create_RELEASES, Reason}))
+                    {error, _Reason} ->
+                        ?log_debug("*WARNING* Creating RELEASES file failed. "
+                                   "The RELEASES file is required before release_handler can be used "
+                                   "to install a release."),
+                        ok
                 end
             after
                 file:set_cwd(OldCWD)

--- a/src/rlx_assemble.erl
+++ b/src/rlx_assemble.erl
@@ -60,8 +60,6 @@ prepare_applications(State, Apps) ->
         true ->
             [rlx_app_info:link(App, true) || App <- Apps];
         false ->
-            %% TODO: since system libs are versioned, maybe we can always use symlinks for them
-            %% [rlx_app_info:link(App, is_system_lib(rlx_app_info:dir(App))) || App <- Apps]
             Apps
     end.
 

--- a/src/rlx_assemble.erl
+++ b/src/rlx_assemble.erl
@@ -691,7 +691,8 @@ copy_boot_to_bin(RelDir, OutputDir, Name) ->
 create_RELEASES(OutputDir, ReleaseFile) ->
     {ok, OldCWD} = file:get_cwd(),
     try
-        file:set_cwd(OutputDir),
+        ok = filelib:ensure_dir(filename:join([OutputDir, "releases", "RELEASES"])),
+        ok = file:set_cwd(OutputDir),
         case release_handler:create_RELEASES("./",
                                              "releases",
                                              ReleaseFile,

--- a/src/rlx_config.erl
+++ b/src/rlx_config.erl
@@ -1,6 +1,6 @@
 -module(rlx_config).
 
--export([to_state/2,
+-export([to_state/1,
          load/2,
          format_error/1]).
 
@@ -11,6 +11,9 @@
 -type t() :: [{atom(), term()}].
 
 -export_type([t/0]).
+
+to_state(Config) ->
+    to_state(Config, rlx_state:new()).
 
 to_state(Config, State) ->
     %% setup warnings_as_errors before loading the rest so we can error on
@@ -166,7 +169,6 @@ try_vsn(Fun) ->
             "0.0.0"
     end.
 
-%% TODO: handle versions in rebar3 or whatever else is calling relx
 git_ref(Arg) ->
     String = rlx_util:sh("git rev-parse " ++ Arg ++ " HEAD"),
     Vsn = rlx_string:trim(String, both, "\n"),
@@ -182,7 +184,6 @@ git_ref(Arg) ->
             "0.0.0"
     end.
 
-%% TODO: handle versions in rebar3 or whatever else is calling relx
 git_tag_vsn() ->
     {Vsn, RawRef, RawCount} = collect_default_refcount(),
     build_vsn_string(Vsn, RawRef, RawCount).

--- a/src/rlx_overlay.erl
+++ b/src/rlx_overlay.erl
@@ -103,8 +103,8 @@ read_overlay_vars(State, OverlayVars, FileNames) ->
     Terms = merge_overlay_vars(State, FileNames),
     case render_overlay_vars(OverlayVars ++ OverlayVarsValues, Terms, []) of
         {ok, NewTerms} ->
-            % We place `OverlayVarsvalues' at the end on purpose; their
-            % definitions should be overwrittenable by both internal
+            % We place `OverlayVarsValues' at the end on purpose; their
+            % definitions should be able to be overwritten by both internal
             % and rendered vars, as not to change behaviour in
             % setups preceding the support for overlays from the caller.
             OverlayVars ++ NewTerms ++ OverlayVarsValues;

--- a/src/rlx_overlay.erl
+++ b/src/rlx_overlay.erl
@@ -86,9 +86,7 @@ generate_overlay_vars(State, Release) ->
 -spec get_overlay_vars_from_file(rlx_state:t(), proplists:proplist()) ->
                                         proplists:proplist() | relx:error().
 get_overlay_vars_from_file(State, OverlayVars) ->
-    case rlx_state:get(State, overlay_vars, undefined) of
-        undefined ->
-            OverlayVars;
+    case rlx_state:overlay_vars(State) of
         [] ->
             OverlayVars;
         [H | _]=FileNames when is_list(H) ;
@@ -101,7 +99,7 @@ get_overlay_vars_from_file(State, OverlayVars) ->
 -spec read_overlay_vars(rlx_state:t(), proplists:proplist(), [file:name()]) ->
                                proplists:proplist() | relx:error().
 read_overlay_vars(State, OverlayVars, FileNames) ->
-    OverlayVarsValues = rlx_state:get(State, overlay_vars_values),
+    OverlayVarsValues = rlx_state:overlay_vars_values(State),
     Terms = merge_overlay_vars(State, FileNames),
     case render_overlay_vars(OverlayVars ++ OverlayVarsValues, Terms, []) of
         {ok, NewTerms} ->
@@ -214,8 +212,8 @@ generate_state_vars(Release, State) ->
 -spec do_overlay(rlx_state:t(), rlx_release:t(), list(), proplists:proplist()) ->
                                    {ok, rlx_state:t()} | relx:error().
 do_overlay(State, Release, Files, OverlayVars) ->
-    case rlx_state:get(State, overlay, undefined) of
-        undefined ->
+    case rlx_state:overlay(State) of
+        [] ->
             {ok, State};
         Overlays ->
             handle_errors(State,

--- a/src/rlx_resolve.erl
+++ b/src/rlx_resolve.erl
@@ -120,7 +120,7 @@ to_app(Name, Vsn, Dir) ->
     AppFile = code:where_is_file(filename:join([[Name, ".app"]])),
     {ok, [{application, _AppName, AppData}]} = file:consult(AppFile),
     Applications = proplists:get_value(applications, AppData, []),
-    IncludedApplications = proplists:get_value(included_applicationsp, AppData, []),
+    IncludedApplications = proplists:get_value(included_applications, AppData, []),
 
     case lists:keyfind(vsn, 1, AppData) of
         {_, Vsn1} when Vsn =:= undefined ;

--- a/src/rlx_resolve.erl
+++ b/src/rlx_resolve.erl
@@ -11,31 +11,27 @@ format_error({no_goals_specified, {RelName, RelVsn}}) ->
     io_lib:format("No applications configured to be included in release ~s-~s", [RelName, RelVsn]);
 format_error({release_erts_error, Dir}) ->
     io_lib:format("Unable to find erts in ~s", [Dir]);
-format_error({release_not_found, {RelName, RelVsn}}) ->
-    io_lib:format("No release named ~s of version ~s found in configuration", [RelName, RelVsn]);
-format_error({app_not_found, App}) ->
-    io_lib:format("Application needed for release not found: ~p", [App]).
+format_error({app_not_found, AppName, AppVsn}) ->
+    io_lib:format("Application needed for release not found: ~p-~s", [AppName, AppVsn]);
+format_error({app_not_found, AppName}) ->
+    io_lib:format("Application needed for release not found: ~p", [AppName]).
 
 solve_release(Release, State0) ->
     RelName = rlx_release:name(Release),
     RelVsn = rlx_release:vsn(Release),
     ?log_debug("Solving Release ~p-~s", [RelName, RelVsn]),
     AllApps = rlx_state:available_apps(State0),
-    try
-        %% get per release config values and override the State with them
-        Config = rlx_release:config(Release),
-        {ok, State1} = lists:foldl(fun rlx_config:load/2, {ok, State0}, Config),
-        case rlx_release:goals(Release) of
-            Goals when map_size(Goals) =:= 0 ->
-                erlang:error(?RLX_ERROR({no_goals_specified, {RelName, RelVsn}}));
-            Goals ->
-                Pkgs = subset(maps:to_list(Goals), AllApps),
-                Pkgs1 = remove_exclude_apps(Pkgs, State1),
-                set_resolved(Release, Pkgs1, State1)
-        end
-    catch
-        throw:not_found ->
-            erlang:error(?RLX_ERROR({release_not_found, {RelName, RelVsn}}))
+
+    %% get per release config values and override the State with them
+    Config = rlx_release:config(Release),
+    {ok, State1} = lists:foldl(fun rlx_config:load/2, {ok, State0}, Config),
+    case rlx_release:goals(Release) of
+        Goals when map_size(Goals) =:= 0 ->
+            erlang:error(?RLX_ERROR({no_goals_specified, {RelName, RelVsn}}));
+        Goals ->
+            Pkgs = subset(maps:to_list(Goals), AllApps),
+            Pkgs1 = remove_exclude_apps(Pkgs, State1),
+            set_resolved(Release, Pkgs1, State1)
     end.
 
 %% find the app_info records for each application and its deps needed for the release
@@ -76,7 +72,7 @@ set_resolved(Release0, Pkgs, State) ->
                         {ok, Release2, rlx_state:add_realized_release(State, Release2)}
                     catch
                         _:_ ->
-                            ?RLX_ERROR({release_erts_error, ErtsDir})
+                            erlang:error(?RLX_ERROR({release_erts_error, ErtsDir}))
                     end
             end
     end.
@@ -99,8 +95,13 @@ find_and_remove(ExcludeName, [#{name := Name} | Rest]) when ExcludeName =:= Name
 find_and_remove(ExcludeName, [H | Rest]) ->
     [H | find_and_remove(ExcludeName, Rest)].
 
-find_app(Name, _Vsn, []) ->
-    error(?RLX_ERROR({app_not_found, Name}));
+find_app(Name, Vsn, []) ->
+    case code:lib_dir(Name) of
+        {error, bad_name} ->
+            erlang:error(?RLX_ERROR({app_not_found, Name}));
+        Dir ->
+            to_app(Name, Vsn, Dir)
+    end;
 find_app(Name, Vsn, [App | Rest]) ->
     case check_app(Name, Vsn, App) of
         true ->
@@ -115,6 +116,26 @@ check_app(Name, Vsn, App) ->
     rlx_app_info:name(App) =:= Name
         andalso rlx_app_info:vsn(App) =:= Vsn.
 
+to_app(Name, Vsn, Dir) ->
+    AppFile = code:where_is_file(filename:join([[Name, ".app"]])),
+    {ok, [{application, _AppName, AppData}]} = file:consult(AppFile),
+    Applications = proplists:get_value(applications, AppData, []),
+    IncludedApplications = proplists:get_value(included_applicationsp, AppData, []),
+
+    case lists:keyfind(vsn, 1, AppData) of
+        {_, Vsn1} when Vsn =:= undefined ;
+                       Vsn =:= Vsn1 ->
+            #{name => Name,
+              vsn => Vsn1,
+
+              applications => Applications,
+              included_applications => IncludedApplications,
+
+              dir => Dir,
+              link => false};
+        _ ->
+            erlang:error(?RLX_ERROR({app_not_found, Name, Vsn}))
+    end.
 
 %% TODO: Support overriding the dirs to search
 %% precedence: apps > deps > erl_libs > system

--- a/src/rlx_resolve.erl
+++ b/src/rlx_resolve.erl
@@ -64,7 +64,7 @@ set_resolved(Release0, Pkgs, State) ->
         {ok, Release1} ->
             ?log_debug("Resolved ~p-~s", [rlx_release:name(Release1), rlx_release:vsn(Release1)]),
             ?log_debug("~s", [rlx_release:format(Release1)]),
-            case rlx_state:get(State, include_erts, undefined) of
+            case rlx_state:include_erts(State) of
                 IncludeErts when is_atom(IncludeErts) ->
                     {ok, Release1, rlx_state:add_realized_release(State, Release1)};
                 ErtsDir ->

--- a/src/rlx_resolve.erl
+++ b/src/rlx_resolve.erl
@@ -117,6 +117,8 @@ check_app(Name, Vsn, App) ->
         andalso rlx_app_info:vsn(App) =:= Vsn.
 
 to_app(Name, Vsn, Dir) ->
+    %% TODO: Support overriding the dirs to search
+    %% precedence: apps > deps > erl_libs > system
     AppFile = code:where_is_file(filename:join([[Name, ".app"]])),
     {ok, [{application, _AppName, AppData}]} = file:consult(AppFile),
     Applications = proplists:get_value(applications, AppData, []),
@@ -136,13 +138,3 @@ to_app(Name, Vsn, Dir) ->
         _ ->
             erlang:error(?RLX_ERROR({app_not_found, Name, Vsn}))
     end.
-
-%% TODO: Support overriding the dirs to search
-%% precedence: apps > deps > erl_libs > system
-%% Dir = code:lib_dir(Name),
-%% case rebar_app_discover:find_app(Dir, valid) of
-%%     {true, A} ->
-%%         A;
-%%     _ ->
-%%         throw({app_not_found, Name})
-%% end

--- a/src/rlx_state.erl
+++ b/src/rlx_state.erl
@@ -52,13 +52,30 @@
          update_realized_release/2,
          available_apps/1,
          available_apps/2,
-         get/2,
-         get/3,
-         put/3,
          dev_mode/1,
          dev_mode/2,
          include_src/1,
          include_src/2,
+         include_erts/1,
+         include_erts/2,
+         include_nodetool/1,
+         include_nodetool/2,
+         system_libs/1,
+         system_libs/2,
+         extended_start_script/1,
+         extended_start_script/2,
+         extended_start_script_hooks/1,
+         extended_start_script_hooks/2,
+         extended_start_script_extensions/1,
+         extended_start_script_extensions/2,
+         overlay/1,
+         overlay/2,
+         overlay_vars_values/1,
+         overlay_vars_values/2,
+         overlay_vars/1,
+         overlay_vars/2,
+         generate_start_script/1,
+         generate_start_script/2,
          upfrom/2,
          format/1,
          format/2,
@@ -92,10 +109,19 @@
                   realized_releases :: releases(),
                   dev_mode=false :: boolean(),
                   include_src :: boolean() | undefined,
+                  include_erts=false :: boolean() | file:filename(),
+                  system_libs=true :: boolean(),
                   upfrom :: string() | binary() | undefined,
-                  config_values :: #{atom() => term()},
                   warnings_as_errors=false :: boolean(),
                   src_tests=true :: boolean(),
+                  overlay=[] :: list(),
+                  include_nodetool=true :: boolean(),
+                  overlay_vars_values=[] :: list(),
+                  overlay_vars=[] :: list(),
+                  extended_start_script=true :: boolean(),
+                  extended_start_script_hooks=[] :: list(),
+                  extended_start_script_extensions=[] :: list(),
+                  generate_start_script=true :: boolean(),
 
                   %% default check is for sasl 3.5 and above
                   %% version 3.5 of sasl has systools with changes for relx
@@ -115,15 +141,13 @@
 
 new() ->
     {ok, Root} = file:get_cwd(),
-    State0 = #state_t{root_dir=Root,
-                      output_dir=filename:join(Root, "_rel"),
-                      configured_releases=#{},
-                      realized_releases=#{},
-                      config_values=#{},
-                      is_relx_sasl=rlx_util:is_sasl_gte()},
-    State1 = rlx_state:put(State0, default_libs, true),
-    State2 = rlx_state:put(State1, overlay_vars_values, []),
-    rlx_state:put(State2, overlay_vars, []).
+    #state_t{root_dir=Root,
+             output_dir=filename:join(Root, "_rel"),
+             configured_releases=#{},
+             realized_releases=#{},
+             is_relx_sasl=rlx_util:is_sasl_gte(),
+             overlay_vars_values=[],
+             overlay_vars=[]}.
 
 %% @doc the application overrides for the system
 -spec overrides(t()) -> [{AppName::atom(), Directory::file:filename()}].
@@ -253,21 +277,6 @@ available_apps(#state_t{available_apps=Apps}) ->
 available_apps(M, NewApps) ->
     M#state_t{available_apps=NewApps}.
 
--spec get(t(), atom()) -> term().
-get(#state_t{config_values=Config}, Key)
-  when erlang:is_atom(Key) ->
-    maps:get(Key, Config).
-
--spec get(t(), atom(), DefaultValue::term()) -> term().
-get(#state_t{config_values=Config}, Key, DefaultValue)
-  when erlang:is_atom(Key) ->
-    maps:get(Key, Config, DefaultValue).
-
--spec put(t(), atom(), term()) ->t().
-put(M=#state_t{config_values=Config}, Key, Value)
-  when erlang:is_atom(Key) ->
-    M#state_t{config_values=Config#{Key => Value}}.
-
 -spec dev_mode(t()) -> boolean().
 dev_mode(#state_t{dev_mode=DevMode}) ->
     DevMode.
@@ -276,6 +285,74 @@ dev_mode(#state_t{dev_mode=DevMode}) ->
 dev_mode(S, DevMode) ->
     S#state_t{dev_mode=DevMode}.
 
+-spec include_erts(t()) -> boolean() | file:filename() | undefined.
+include_erts(#state_t{include_erts=IncludeErts}) ->
+    IncludeErts.
+
+-spec include_erts(t(), boolean() | file:filename()) -> t().
+include_erts(S, IncludeErts) ->
+    S#state_t{include_erts=IncludeErts}.
+
+-spec include_nodetool(t()) -> boolean() | file:filename() | undefined.
+include_nodetool(#state_t{include_nodetool=IncludeNodetool}) ->
+    IncludeNodetool.
+
+-spec include_nodetool(t(), boolean() | file:filename()) -> t().
+include_nodetool(S, IncludeNodetool) ->
+    S#state_t{include_nodetool=IncludeNodetool}.
+
+-spec overlay(t()) -> list() | undefined.
+overlay(#state_t{overlay=Overlay}) ->
+    Overlay.
+
+-spec overlay(t(), list()) -> t().
+overlay(S, Overlay) ->
+    S#state_t{overlay=Overlay}.
+
+overlay_vars_values(#state_t{overlay_vars_values=OverlayVarsValues}) ->
+    OverlayVarsValues.
+
+overlay_vars_values(S, OverlayVarsValues) ->
+    S#state_t{overlay_vars_values=OverlayVarsValues}.
+
+overlay_vars(#state_t{overlay_vars=OverlayVars}) ->
+    OverlayVars.
+
+overlay_vars(S, OverlayVars) ->
+    S#state_t{overlay_vars=OverlayVars}.
+
+-spec extended_start_script_hooks(t()) -> list() | undefined.
+extended_start_script_hooks(#state_t{extended_start_script_hooks=ExtendedStartScriptHooks}) ->
+    ExtendedStartScriptHooks.
+
+-spec extended_start_script_hooks(t(), list()) -> t().
+extended_start_script_hooks(S, ExtendedStartScriptHooks) ->
+    S#state_t{extended_start_script_hooks=ExtendedStartScriptHooks}.
+
+-spec extended_start_script_extensions(t()) -> list() | undefined.
+extended_start_script_extensions(#state_t{extended_start_script_extensions=ExtendedStartScriptExtensions}) ->
+    ExtendedStartScriptExtensions.
+
+-spec extended_start_script_extensions(t(), list()) -> t().
+extended_start_script_extensions(S, ExtendedStartScriptExtensions) ->
+    S#state_t{extended_start_script_extensions=ExtendedStartScriptExtensions}.
+
+-spec extended_start_script(t()) -> boolean() | undefined.
+extended_start_script(#state_t{extended_start_script=ExtendedStartScript}) ->
+    ExtendedStartScript.
+
+-spec extended_start_script(t(), boolean()) -> t().
+extended_start_script(S, ExtendedStartScript) ->
+    S#state_t{extended_start_script=ExtendedStartScript}.
+
+-spec generate_start_script(t()) -> boolean() | undefined.
+generate_start_script(#state_t{generate_start_script=GenerateStartScript}) ->
+    GenerateStartScript.
+
+-spec generate_start_script(t(), boolean()) -> t().
+generate_start_script(S, GenerateStartScript) ->
+    S#state_t{generate_start_script=GenerateStartScript}.
+
 -spec include_src(t()) -> boolean() | undefined.
 include_src(#state_t{include_src=IncludeSrc}) ->
     IncludeSrc.
@@ -283,6 +360,14 @@ include_src(#state_t{include_src=IncludeSrc}) ->
 -spec include_src(t(), boolean()) -> t().
 include_src(S, IncludeSrc) ->
     S#state_t{include_src=IncludeSrc}.
+
+-spec system_libs(t()) -> boolean() | undefined.
+system_libs(#state_t{system_libs=SystemLibs}) ->
+    SystemLibs.
+
+-spec system_libs(t(), boolean()) -> t().
+system_libs(S, SystemLibs) ->
+    S#state_t{system_libs=SystemLibs}.
 
 -spec upfrom(t(), string() | binary() | undefined) -> t().
 upfrom(State, UpFrom) ->
@@ -294,17 +379,13 @@ format(Mod) ->
 
 -spec format(t(), non_neg_integer()) -> iolist().
 format(#state_t{output_dir=OutDir, 
-                lib_dirs=LibDirs,
-                config_values=Values0},
+                lib_dirs=LibDirs},
        Indent) ->
-    Values1 = maps:to_list(Values0),
     [rlx_util:indent(Indent),
      <<"state:\n">>,
      rlx_util:indent(Indent + 2), "output_dir: ", OutDir, "\n",
      rlx_util:indent(Indent + 2), "lib_dirs: \n",
-     [[rlx_util:indent(Indent + 3), LibDir, ",\n"] || LibDir <- LibDirs],
-     rlx_util:indent(Indent + 2), "config values: \n",
-     [[rlx_util:indent(Indent + 3), io_lib:format("~p", [Value]), ",\n"] || Value <- Values1]].
+     [[rlx_util:indent(Indent + 3), LibDir, ",\n"] || LibDir <- LibDirs]].
 
 -spec warnings_as_errors(t()) -> boolean().
 warnings_as_errors(#state_t{warnings_as_errors=WarningsAsErrors}) ->

--- a/src/rlx_state.erl
+++ b/src/rlx_state.erl
@@ -95,8 +95,6 @@
                   lib_dirs=[] :: [file:name()],
                   config_file=[] :: file:filename() | undefined,
                   available_apps=[] :: [rlx_app_info:t()],
-                  default_configured_release :: {rlx_release:name() | undefined,
-                                                 rlx_release:vsn() |undefined} | undefined,
                   vm_args :: file:filename() | false | undefined,
                   vm_args_src :: file:filename() | undefined,
                   sys_config :: file:filename() | false | undefined,

--- a/src/rlx_util.erl
+++ b/src/rlx_util.erl
@@ -211,7 +211,7 @@ os_type(State) ->
   end.
 
 include_erts_is_win32(State) ->
-  case rlx_state:get(State, include_erts, true) of
+  case rlx_state:include_erts(State) of
     true -> false;
     false -> false;
     Path -> is_win32_erts(Path)

--- a/test/rlx_extended_bin_SUITE.erl
+++ b/test/rlx_extended_bin_SUITE.erl
@@ -1159,7 +1159,7 @@ custom_start_script_hooks(Config) ->
                                                               {custom, "hooks/post_stop"}
                                                              ]}
                                                 ]},
-                  {mkdir, "scripts"},
+
                   {overlay, [{copy, "./{pre,post}_{start,stop}", "bin/hooks/"}]}
                  ],
 
@@ -1239,7 +1239,7 @@ custom_start_script_hooks_console(Config) ->
                                                               {custom, "hooks/pre_start"}
                                                              ]}
                                                 ]},
-                  {mkdir, "scripts"},
+
                   {overlay, [{copy, "./pre_start", "bin/hooks/pre_start"}]}
                  ],
 
@@ -1361,7 +1361,7 @@ mixed_custom_and_builtin_start_script_hooks(Config) ->
                                                               {custom, "hooks/post_stop"}
                                                              ]}
                                                 ]},
-                  {mkdir, "scripts"},
+
                   {overlay, [{copy, "./pre_start", "bin/hooks/pre_start"},
                              {copy, "./post_start", "bin/hooks/post_start"},
                              {copy, "./pre_stop", "bin/hooks/pre_stop"},


### PR DESCRIPTION
Also adds support for checking the code path for libraries missing from the applications passed to `relx:build_*`. This will have to change to allow overriding by the configuration like `system_libs` which can be a path to where to find applications.