### PR TITLE
merge use of nodetool and erl_call depending on ERTS version

### DIFF
--- a/priv/templates/builtin_hook_pid
+++ b/priv/templates/builtin_hook_pid
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # loop until the VM starts responding to pings
-while ! relx_nodetool "ping">/dev/null
+while ! erl_rpc erlang is_alive > /dev/null
 do
     sleep 1
 done

--- a/priv/templates/builtin_hook_status
+++ b/priv/templates/builtin_hook_status
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-relx_nodetool eval "application:which_applications()."
+erl_eval "application:which_applications()."

--- a/priv/templates/builtin_hook_wait_for_process
+++ b/priv/templates/builtin_hook_wait_for_process
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # loop until the VM starts responding to pings
-while ! relx_nodetool "ping">/dev/null
+while ! erl_rpc erlang is_alive > /dev/null
 do
     sleep 1
 done
@@ -10,7 +10,7 @@ done
 # registered
 while true
 do
-    if [ "$(relx_nodetool eval "whereis($1).")" != "undefined" ]
+    if [ "$(erl_eval "whereis($1).")" != "undefined" ]
     then
         break
     fi

--- a/priv/templates/builtin_hook_wait_for_vm_start
+++ b/priv/templates/builtin_hook_wait_for_vm_start
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # loop until the VM starts responding to pings
-while ! relx_nodetool "ping">/dev/null
+while ! erl_rpc erlang is_alive > /dev/null
 do
     sleep 1
 done

--- a/priv/templates/extended_bin
+++ b/priv/templates/extended_bin
@@ -19,6 +19,7 @@ fi
 
 # OSX does not support readlink '-f' flag, work
 # around that
+# shellcheck disable=SC2039
 case $OSTYPE in
     darwin*)
         SCRIPT=$(readlink "$0" || true)
@@ -132,15 +133,34 @@ find_erts_dir() {
     fi
 }
 
+find_erl_call() {
+    # only OTP-23 and above have erl_call in the erts bin directory
+    # and only those versions have the features and bug fixes needed
+    # to work properly with this script
+    __erl_call="$ERTS_DIR/bin/erl_call"
+    if [ -f "$__erl_call" ]; then
+        ERL_RPC="$__erl_call";
+    else
+        ERL_RPC=relx_nodetool
+    fi
+}
+
 # Get node pid
 relx_get_pid() {
-    if output="$(relx_nodetool rpcterms os getpid)"
+    if output="$(erl_rpc os getpid)"
     then
         echo "$output" | sed -e 's/"//g'
         return 0
     else
         echo "$output"
         return 1
+    fi
+}
+
+ping_or_exit() {
+    if ! erl_rpc erlang is_alive > /dev/null 2>&1; then
+        echo "Node is not running!"
+        exit 1
     fi
 }
 
@@ -172,11 +192,11 @@ relx_rem_sh() {
     id="remsh$(relx_gen_id)-${NAME}"
 
     # Get the node's ticktime so that we use the same thing.
-    TICKTIME="$(relx_nodetool rpcterms net_kernel get_net_ticktime)"
+    TICKTIME="$(erl_rpc net_kernel get_net_ticktime)"
 
     # Setup remote shell command to control node
     # -dist_listen is new in OTP-23. It keeps the remote node from binding to a listen port
-    # and implies the optoin -hidden
+    # and implies the option -hidden
     exec "$BINDIR/erl" "$NAME_TYPE" "$id" -remsh "$NAME" -boot "$REL_DIR"/start_clean -mode interactive \
          -boot_var SYSTEM_LIB_DIR "$SYSTEM_LIB_DIR" \
          -setcookie "$COOKIE" -hidden -kernel net_ticktime "$TICKTIME" \
@@ -184,12 +204,52 @@ relx_rem_sh() {
          "$MAYBE_DIST_ARGS"
 }
 
+erl_rpc() {
+    case "$ERL_RPC" in
+        "relx_nodetool")
+            echo "relx_nodetool rpc $@"
+            relx_nodetool rpc "$@"
+            ;;
+        *)
+            command=$*
+
+            result=$("$ERL_RPC" "$NAME_TYPE" "$NAME" -c "${COOKIE}" -a "${command}")
+            code=$?
+            if [ $code -eq 0 ]; then
+                echo "$result" | tr -d "\n"
+            else
+                return $code
+            fi
+            ;;
+    esac
+}
+
+erl_eval() {
+    case "$ERL_RPC" in
+        "relx_nodetool")
+            relx_nodetool eval "$@"
+            ;;
+        *)
+            command=$*
+
+            result=$(echo "${command}" | "$ERL_RPC" "$NAME_TYPE" "$NAME" -c "${COOKIE}" -e)
+            code=$?
+            if [ $code -eq 0 ]; then
+                echo "$result" | sed 's/^{ok, \(.*\)}$/\1/' | tr -d "\n"
+            else
+                return $code
+            fi
+            ;;
+    esac
+}
+
+
 # Generate a random id
 relx_gen_id() {
     od -t x -N 4 /dev/urandom | head -n1 | awk '{print $2}'
 }
 
-# Control a node
+# Control a node with nodetool if erl_call isn't from OTP-23+
 relx_nodetool() {
     command="$1"; shift
 
@@ -312,11 +372,13 @@ relx_run_hooks() {
         # by empty spaces and give them to the `set`
         # command in order to be able to extract them
         # separately
+        # shellcheck disable=SC2046
         set $(echo "$hook" | sed -e 's/|/ /g')
         HOOK_SCRIPT=$1; shift
         # all hook locations are expected to be
         # relative to the start script location
-        [ "$SCRIPT_DIR/$HOOK_SCRIPT" ] && . "$SCRIPT_DIR/$HOOK_SCRIPT" "$@"
+        # shellcheck disable=SC1090,SC2240
+        [ -f "$SCRIPT_DIR/$HOOK_SCRIPT" ] && . "$SCRIPT_DIR/$HOOK_SCRIPT" "$@"
     done
 }
 
@@ -361,7 +423,8 @@ relx_run_extension() {
     shift
     # all extension script locations are expected to be
     # relative to the start script location
-    [ "$SCRIPT_DIR/$EXTENSION_SCRIPT" ] && . "$SCRIPT_DIR/$EXTENSION_SCRIPT" "$@"
+    # shellcheck disable=SC1090,SC2240
+    [ -f "$SCRIPT_DIR/$EXTENSION_SCRIPT" ] && . "$SCRIPT_DIR/$EXTENSION_SCRIPT" "$@"
 }
 
 # given a list of arguments, identify the internal ones
@@ -385,6 +448,7 @@ process_internal_args() {
 process_internal_args "$@"
 
 find_erts_dir
+find_erl_call
 export ROOTDIR="$RELEASE_ROOT_DIR"
 export BINDIR="$ERTS_DIR/bin"
 export EMU="beam"
@@ -534,10 +598,12 @@ case "$1" in
         esac
         ARGS="$(printf "'%s' " "$@")"
 
-        # Export the HEART_COMMAND
+        # shellcheck disable=SC2090,SC2089
         HEART_COMMAND="\"$RELEASE_ROOT_DIR/bin/$REL_NAME\" \"$HEART_OPTION\" $ARGS"
+        # shellcheck disable=SC2090
         export HEART_COMMAND
 
+        # shellcheck disable=SC2174
         test -z "$PIPE_BASE_DIR" || mkdir -m 1777 -p "$PIPE_BASE_DIR"
         mkdir -p "$PIPE_DIR"
         if [ ! -w "$PIPE_DIR" ]
@@ -551,7 +617,14 @@ case "$1" in
 
         relx_run_hooks "$PRE_START_HOOKS"
         "$BINDIR/run_erl" -daemon "$PIPE_DIR" "$RUNNER_LOG_DIR" \
-            "exec \"$RELEASE_ROOT_DIR/bin/$REL_NAME\" \"$START_OPTION\" $ARGS --relx-disable-hooks"
+                          "exec \"$RELEASE_ROOT_DIR/bin/$REL_NAME\" \"$START_OPTION\" $ARGS --relx-disable-hooks"
+
+        # wait for node to be up before running hooks
+        while ! erl_rpc erlang is_alive > /dev/null 2>&1
+        do
+            sleep 1
+        done
+
         relx_run_hooks "$POST_START_HOOKS"
         ;;
 
@@ -559,26 +632,33 @@ case "$1" in
         relx_run_hooks "$PRE_STOP_HOOKS"
         # Wait for the node to completely stop...
         PID="$(relx_get_pid)"
-        if ! relx_nodetool "stop"; then
+        if ! erl_rpc init stop > /dev/null; then
             exit 1
         fi
         while kill -s 0 "$PID" 2>/dev/null;
         do
             sleep 1
         done
+
+        # wait for node to be down before running hooks
+        while erl_rpc erlang is_alive > /dev/null 2>&1
+        do
+            sleep 1
+        done
+
         relx_run_hooks "$POST_STOP_HOOKS"
         ;;
 
     restart)
         ## Restart the VM without exiting the process
-        if ! relx_nodetool "restart"; then
+        if ! erl_rpc init restart > /dev/null; then
             exit 1
         fi
         ;;
 
     reboot)
         ## Restart the VM completely (uses heart to restart it)
-        if ! relx_nodetool "reboot"; then
+        if ! erl_rpc init reboot > /dev/null; then
             exit 1
         fi
         ;;
@@ -592,9 +672,9 @@ case "$1" in
 
     ping)
         ## See if the VM is alive
-        if ! relx_nodetool "ping"; then
-            exit 1
-        fi
+        ping_or_exit
+
+        echo "pong"
         ;;
 
     escript)
@@ -607,10 +687,7 @@ case "$1" in
 
     attach)
         # Make sure a node IS running
-        if ! relx_nodetool "ping" > /dev/null; then
-            echo "Node is not running!"
-            exit 1
-        fi
+        ping_or_exit
 
         if [ ! -w "$PIPE_DIR" ]
         then
@@ -624,10 +701,7 @@ case "$1" in
 
     remote_console)
         # Make sure a node IS running
-        if ! relx_nodetool "ping" > /dev/null; then
-            echo "Node is not running!"
-            exit 1
-        fi
+        ping_or_exit
 
         shift
         relx_rem_sh
@@ -643,10 +717,7 @@ case "$1" in
         COMMAND="$1"; shift
 
         # Make sure a node IS running
-        if ! relx_nodetool "ping" > /dev/null; then
-            echo "Node is not running!"
-            exit 1
-        fi
+        ping_or_exit
 
         relx_run_hooks "$PRE_INSTALL_UPGRADE_HOOKS"
 
@@ -658,10 +729,7 @@ case "$1" in
 
     versions)
         # Make sure a node IS running
-        if ! relx_nodetool "ping" > /dev/null; then
-            echo "Node is not running!"
-            exit 1
-        fi
+        ping_or_exit
 
         COMMAND="$1"; shift
 
@@ -724,7 +792,7 @@ case "$1" in
 
         # Log the startup
         echo "$RELEASE_ROOT_DIR"
-        logger -t "$REL_NAME[$$]" "Starting up"
+        logger -t "${REL_NAME}[$$]" "Starting up"
 
         relx_run_hooks "$PRE_START_HOOKS"
         # Start the VM
@@ -739,44 +807,26 @@ case "$1" in
         ;;
     rpc)
         # Make sure a node IS running
-        if ! relx_nodetool "ping" > /dev/null; then
-            echo "Node is not running!"
-            exit 1
-        fi
+        ping_or_exit
 
         shift
 
-        relx_nodetool rpc "$@"
-        ;;
-    rpcterms)
-        # Make sure a node IS running
-        if ! relx_nodetool "ping" > /dev/null; then
-            echo "Node is not running!"
-            exit 1
-        fi
-
-        shift
-
-        relx_nodetool rpcterms "$@"
+        erl_rpc "$@"
         ;;
     eval)
         # Make sure a node IS running
-        if ! relx_nodetool "ping" > /dev/null; then
-            echo "Node is not running!"
-            exit 1
-        fi
+        ping_or_exit
 
         shift
-        relx_nodetool "eval" "$@"
+
+        erl_eval "$@"
         ;;
     status)
         # Make sure a node IS running
-        if ! relx_nodetool "ping" > /dev/null; then
-            echo "Node is not running!"
-            exit 1
-        fi
+        ping_or_exit
 
-        [ -n "${STATUS_HOOK}" ] && [ "$SCRIPT_DIR/$STATUS_HOOK" ] && . "$SCRIPT_DIR/$STATUS_HOOK" "$@"
+        # shellcheck disable=SC1090,SC2240
+        [ -n "${STATUS_HOOK}" ] && [ -f "$SCRIPT_DIR/$STATUS_HOOK" ] && . "$SCRIPT_DIR/$STATUS_HOOK" "$@"
         ;;
     help)
         if [ -z "$2" ]; then

--- a/priv/templates/nodetool
+++ b/priv/templates/nodetool
@@ -5,6 +5,10 @@
 %%
 %% nodetool: Helper Script for interacting with live nodes
 %%
+%% On releases running with OTP-23+ this escript is not used. Instead,
+%% the `erl_call' command is used. This escript will be removed from
+%% relx when OTP-23 becomes the earliest support version of OTP.
+%%
 %% -------------------------------------------------------------------
 
 main(Args) ->
@@ -18,7 +22,7 @@ main(Args) ->
         {true, pong} ->
             ok;
         {_, pang} ->
-            io:format("Node ~p not responding to pings.\n", [TargetNode]),
+            io:format("Node ~p not responding to pings.~n", [TargetNode]),
             halt(1)
     end,
 
@@ -35,35 +39,22 @@ main(Args) ->
         end,
 
     case RestArgs of
-        ["ping"] ->
-            %% If we got this far, the node already responsed to a ping, so just dump
-            %% a "pong"
-            io:format("pong\n");
-        ["stop"] ->
-            io:format("~p\n", [rpc:call(TargetNode, init, stop, [], Timeout)]);
-        ["restart"] ->
-            io:format("~p\n", [rpc:call(TargetNode, init, restart, [], Timeout)]);
-        ["reboot"] ->
-            io:format("~p\n", [rpc:call(TargetNode, init, reboot, [], Timeout)]);
-        ["rpc", Module, Function | RpcArgs] ->
-            case rpc:call(TargetNode, list_to_atom(Module), list_to_atom(Function),
-                          [RpcArgs], Timeout) of
-                ok ->
-                    ok;
-                {badrpc, Reason} ->
-                    io:format("RPC to ~p failed: ~p\n", [TargetNode, Reason]),
-                    halt(1);
-                _ ->
-                    halt(1)
-            end;
-        ["rpcterms", Module, Function | ArgsAsString] ->
-            case rpc:call(TargetNode, list_to_atom(Module), list_to_atom(Function),
-                          consult(lists:flatten(ArgsAsString)), Timeout) of
-                {badrpc, Reason} ->
-                    io:format("RPC to ~p failed: ~p\n", [TargetNode, Reason]),
-                    halt(1);
-                Other ->
-                    io:format("~p\n", [Other])
+        ["rpc", Module, Function | ArgsAsString] ->
+            case consult(lists:flatten(ArgsAsString)) of
+                {error, Reason} ->
+                    io:format("Error parsing arguments `~s`, failed with reason: ~s~n", [ArgsAsString, Reason]);
+                {ok, ParsedArgs} when is_list(ParsedArgs) ->
+                    case rpc:call(TargetNode, list_to_atom(Module),
+                                  list_to_atom(Function), ParsedArgs, Timeout) of
+                        {badrpc, Reason} ->
+                            io:format("RPC to ~p failed: ~p~n", [TargetNode, Reason]),
+                            halt(1);
+                        Other ->
+                            io:format("~p~n", [Other])
+                    end;
+                {ok, ParsedArgs} ->
+                    io:format("Error: args `~p` not a list.~n"
+                              "Example to call `foo:bar(1,2,3)` pass `foo bar \"[1, 2, 3].\"`~n", [ParsedArgs])
             end;
         ["eval" | ListOfArgs] ->
             % shells may process args into more than one, and end up stripping
@@ -89,14 +80,14 @@ main(Args) ->
             % and evaluate it on the remote node
             case rpc:call(TargetNode, erl_eval, exprs, [Parsed, [] ]) of
                 {value, Value, _} ->
-                    io:format ("~p\n",[Value]);
+                    io:format ("~p~n",[Value]);
                 {badrpc, Reason} ->
-                    io:format("RPC to ~p failed: ~p\n", [TargetNode, Reason]),
+                    io:format("RPC to ~p failed: ~p~n", [TargetNode, Reason]),
                     halt(1)
             end;
         Other ->
-            io:format("Other: ~p\n", [Other]),
-            io:format("Usage: nodetool {ping|stop|restart|reboot|rpc|rpcterms|eval [Terms]} [RPC]\n")
+            io:format("Other: ~p~n", [Other]),
+            io:format("Usage: nodetool {ping|stop|restart|reboot|rpc|rpcterms|eval [Terms]} [RPC]~n")
     end,
     net_kernel:stop().
 
@@ -165,28 +156,22 @@ append_node_suffix(Name, Suffix) ->
             list_to_atom(lists:concat([Node, Suffix, os:getpid()]))
     end.
 
-%%
-%% Given a string or binary, parse it into a list of terms, ala file:consult/0
-%%
-consult(Str) when is_list(Str) ->
-    consult([], Str, []);
+%% convert string to erlang term
+consult([]) ->
+    {ok, []};
 consult(Bin) when is_binary(Bin)->
-    consult([], binary_to_list(Bin), []).
-
-consult(Cont, Str, Acc) ->
-    case erl_scan:tokens(Cont, Str, 0) of
-        {done, Result, Remaining} ->
-            case Result of
-                {ok, Tokens, _} ->
-                    {ok, Term} = erl_parse:parse_term(Tokens),
-                    consult([], Remaining, [Term | Acc]);
-                {eof, _Other} ->
-                    lists:reverse(Acc);
-                {error, Info, _} ->
-                    {error, Info}
+    consult(binary_to_list(Bin));
+consult(Str) when is_list(Str) ->
+    case erl_scan:string(Str) of
+        {ok, Tokens, _} ->
+            case erl_parse:parse_term(Tokens) of
+                {ok, Args} ->
+                    {ok, Args};
+                {error, {_, _, ErrorDescriptor}} ->
+                    {error, erl_parse:format_error(ErrorDescriptor)}
             end;
-        {more, Cont1} ->
-            consult(Cont1, eof, Acc)
+        {error, {_, _, ErrorDescriptor}} ->
+            {error, erl_scan:format_error(ErrorDescriptor)}
     end.
 
 %% string:join/2 copy; string:join/2 is getting obsoleted

--- a/rebar.config
+++ b/rebar.config
@@ -19,7 +19,7 @@
 {cover_excl_mods, [bin_dtl, erl_script_dtl, extended_bin_dtl,
                    extended_bin_windows_dtl, erl_ini_dtl,
                    bin_windows_dtl, nodetool_dtl,
-                   install_upgrade_escript_dtl, nodetool_dtl,
+                   install_upgrade_escript_dtl,
                    sys_config_dtl, vm_args_dtl, relx]}.
 
 %% ignore warnings about unused exports for functions that are part of

--- a/src/rlx_assemble.erl
+++ b/src/rlx_assemble.erl
@@ -518,7 +518,7 @@ include_erts(State, Release, OutputDir, RelDir) ->
         false ->
             make_boot_script(State, Release, OutputDir, RelDir);
         _ ->
-            ?log_info("Including Erts from ~s", [Prefix]),
+            ?log_debug("Including Erts from ~s", [Prefix]),
             ErtsVersion = rlx_release:erts(Release),
             ErtsBinDir = filename:join([Prefix, "erts-" ++ ErtsVersion, "bin"]),
             LocalErtsBin = filename:join([OutputDir, "erts-" ++ ErtsVersion, "bin"]),

--- a/test/rlx_extended_bin_SUITE.erl
+++ b/test/rlx_extended_bin_SUITE.erl
@@ -29,7 +29,7 @@
 all() ->
     case erlang:system_info(otp_release) of
         %% make them never run for now
-        "22" ->
+        V when V =:= "22" ; V =:= "23" ->
             [{group, shortname},
              {group, longname},
              {group, custom_replace_vars},
@@ -109,7 +109,6 @@ init_per_group(shortname, Config) ->
 
     {ok, _State} = relx:build_release(foo, [{root_dir, LibDir1}, {lib_dirs, [LibDir1]},
                                             {output_dir, OutputDir} | RelxConfig]),
-
 
     {ok, _} = sh(filename:join([OutputDir, "foo", "bin", "foo start"])),
     timer:sleep(?SLEEP_TIME),


### PR DESCRIPTION
this patch updates the extended start script to check for a new
enough erl_call and use this for rpc and eval calls if available.
The release will continue to bundle in nodetool as a fallback
even for releases built for OTP-23+ since it is simpler to do the
check at runtime.

the start script rpcterms option is removed and the rpc option
has changed so that both erl_call and nodetool work the same.
Arguments to function call must be a quoted list ending with a
period, like `bin/foo rpc bar waz '[1,2,3].'` will call the
function `bar:waz(1,2,3)` on the running node.