### PR TITLE
Fix foreground subcommand with shell/input

### DIFF
--- a/priv/templates/extended_bin
+++ b/priv/templates/extended_bin
@@ -844,7 +844,7 @@ case "$1" in
         export PROGNAME
 
         # Dump environment info for logging purposes
-        echo "Exec: $BINDIR/erlexec" "$FOREGROUNDOPTIONS" \
+        echo "Exec: $BINDIR/erlexec" $FOREGROUNDOPTIONS \
             -boot "$BOOTFILE" -mode "$CODE_LOADING_MODE" \
             -boot_var SYSTEM_LIB_DIR "$SYSTEM_LIB_DIR" \
             -config "$RELX_CONFIG_PATH" \
@@ -857,7 +857,8 @@ case "$1" in
 
         relx_run_hooks "$PRE_START_HOOKS"
         # Start the VM
-        exec "$BINDIR/erlexec" "$FOREGROUNDOPTIONS" \
+        # The variabre FOREGROUNDOPTIONS must NOT be quoted.
+        exec "$BINDIR/erlexec" $FOREGROUNDOPTIONS \
             -boot "$BOOTFILE" -mode "$CODE_LOADING_MODE" \
             -boot_var SYSTEM_LIB_DIR "$SYSTEM_LIB_DIR" \
             -config "$RELX_CONFIG_PATH" \

--- a/priv/templates/extended_bin
+++ b/priv/templates/extended_bin
@@ -844,6 +844,7 @@ case "$1" in
         export PROGNAME
 
         # Dump environment info for logging purposes
+        # shellcheck disable=SC2086
         echo "Exec: $BINDIR/erlexec" $FOREGROUNDOPTIONS \
             -boot "$BOOTFILE" -mode "$CODE_LOADING_MODE" \
             -boot_var SYSTEM_LIB_DIR "$SYSTEM_LIB_DIR" \
@@ -858,6 +859,7 @@ case "$1" in
         relx_run_hooks "$PRE_START_HOOKS"
         # Start the VM
         # The variabre FOREGROUNDOPTIONS must NOT be quoted.
+        # shellcheck disable=SC2086
         exec "$BINDIR/erlexec" $FOREGROUNDOPTIONS \
             -boot "$BOOTFILE" -mode "$CODE_LOADING_MODE" \
             -boot_var SYSTEM_LIB_DIR "$SYSTEM_LIB_DIR" \


### PR DESCRIPTION
Before this PR, foreground subcommand shows shell prompt as console subcommand.

```
% rebar3 shell
1> relx:build_release(foo, [{release, {foo, "1"}, [kernel,stdlib,sasl]}]).

(default) % _rel/foo/bin/foo foreground
Exec: /home/shino/local/otp/OTP-22.3/erts-10.7/bin/erlexec -noshell -noinput +Bd -boot /home/shino/g/relx/_rel/foo/releases/1/foo -mode interactive -boot_var SYSTEM_LIB_DIR /home/shino/local/otp/OTP-22.3/lib -config /home/shino/g/relx/_rel/foo/releases/1/sys.config -args_file /home/shino/g/relx/_rel/foo/releases/1/vm.args -- foreground
Root: /home/shino/g/relx/_rel/foo
/home/shino/g/relx/_rel/foo
Erlang/OTP 22 [erts-10.7] [source] [64-bit] [smp:16:16] [ds:16:16:10] [async-threads:1]

Eshell V10.7  (abort with ^G)
(foo@shino-xps)1>
```

By quoting of FOREGROUNDOPTIONS in extended start script, `-noshell -noinput +Bd` is treated as single arg instead of three separated args. This PR just removes the quoting.
There would be more sophisticated and platform independent ways to resolve the issue, but I don't have much skill about shell script... :sweat_smile: So, other approaches are welcome!
