### PR TITLE
unquote MAYBE_DIST_ARGS in extended start script so they work

### DIFF
--- a/priv/templates/extended_bin
+++ b/priv/templates/extended_bin
@@ -283,11 +283,12 @@ relx_rem_sh() {
     # Setup remote shell command to control node
     # -dist_listen is new in OTP-23. It keeps the remote node from binding to a listen port
     # and implies the option -hidden
+    # shellcheck disable=SC2086
     exec "$BINDIR/erl" "${remote_nodename}" -remsh "$NAME" -boot "$REL_DIR"/start_clean -mode interactive \
          -boot_var SYSTEM_LIB_DIR "$SYSTEM_LIB_DIR" \
          -setcookie "$COOKIE" -hidden -kernel net_ticktime "$TICKTIME" \
          -dist_listen false \
-         "$MAYBE_DIST_ARGS"
+         $MAYBE_DIST_ARGS
 }
 
 erl_rpc() {


### PR DESCRIPTION
Quoting like "$MAYBE_DIST_ARGS" results in `erl` not reading
each as a separate argument and will break remote_console for
cases the user has custom arguments like -proto_dist and
-epmd_module in their vm.args