### PR TITLE
move create_RELEASES function to relx

### DIFF
--- a/src/rlx_tar.erl
+++ b/src/rlx_tar.erl
@@ -9,7 +9,8 @@
 make_tar(Release, OutputDir, State) ->
     Name = rlx_release:name(Release),
     Vsn = rlx_release:vsn(Release),
-    ?log_info("Building release tarball...", []),
+    TarFile = filename:join(OutputDir, [Name, "-", Vsn, ".tar.gz"]),
+    ?log_info("Building release tarball ~s...", [filename:basename(TarFile)]),
 
     ExtraFiles = extra_files(Release, OutputDir, State),
     Opts = make_tar_opts(ExtraFiles, Release, OutputDir, State),
@@ -18,7 +19,6 @@ make_tar(Release, OutputDir, State) ->
         Result when Result =:= ok orelse (is_tuple(Result) andalso
                                           element(1, Result) =:= ok) ->
             maybe_print_warnings(Result),
-            TarFile = filename:join(OutputDir, [Name, "-", Vsn, ".tar.gz"]),
             {ok, State1} = case rlx_state:is_relx_sasl(State) of
                                true ->
                                    %% we used extra_files to copy in the overlays


### PR DESCRIPTION
The version in sasl's release_handler module required use of
set_cwd to get a result where the application list had the apps
as relative to the root of the release -- "./lib/..." -- instead
of requiring a newer version of OTP (after getting a new version
into OTP) having this small function added to relx until we only
support versions with the new release_handler module is not a
burden and makes things simpler.

Part of why set_cwd is bad is it makes parallel release building
not an option because of conflicting changes to cwd.