### PR TITLE
Correctly delete symlinks on windows (resolves #801)

### DIFF
--- a/shelltests/powershell_release/rebar.config
+++ b/shelltests/powershell_release/rebar.config
@@ -5,7 +5,8 @@
          [powershell_release, sasl]},
         {sys_config, "./config/sys.config"},
         {vm_args, "./config/vm.args"},
-        {dev_mode, true},
         {extended_start_script, true},
         {start_script_type, "powershell"}]
 }.
+
+{profiles, [{dev, [{relx, [{dev_mode, true}]}]}]}.

--- a/shelltests/powershell_release/rebar.config
+++ b/shelltests/powershell_release/rebar.config
@@ -5,6 +5,7 @@
          [powershell_release, sasl]},
         {sys_config, "./config/sys.config"},
         {vm_args, "./config/vm.args"},
+        {dev_mode, true},
         {extended_start_script, true},
         {start_script_type, "powershell"}]
 }.

--- a/shelltests/wintest.ps1
+++ b/shelltests/wintest.ps1
@@ -54,8 +54,9 @@ Set-Location ".\$release\"
 Rebar release
 ""
 
-"*** Rebuild release (test for symlink issues)"
-Rebar release
+"*** Rebuild dev release (test for symlink issues)"
+Rebar as dev release
+Rebar as dev release
 ""
 
 # Go to release

--- a/shelltests/wintest.ps1
+++ b/shelltests/wintest.ps1
@@ -54,6 +54,10 @@ Set-Location ".\$release\"
 Rebar release
 ""
 
+"*** Rebuild release (test for symlink issues)"
+Rebar release
+""
+
 # Go to release
 Set-Location "_build\default\rel\$release\bin"
 

--- a/shelltests/wintest.ps1
+++ b/shelltests/wintest.ps1
@@ -45,7 +45,12 @@ Pop-Location
 ""
 
 # Function to run rebar3
-function Rebar() { & $erlpath\bin\escript.exe "$rebar3_dir\rebar3" @args }
+function Rebar() {
+    & $erlpath\bin\escript.exe "$rebar3_dir\rebar3" @args
+    if ($LASTEXITCODE -ne 0) {
+        Write-Error "rebar3 ${args} exited with status $LASTEXITCODE"
+    }
+}
 
 # Our release source
 Set-Location ".\$release\"
@@ -64,20 +69,35 @@ Set-Location "_build\default\rel\$release\bin"
 
 "*** Install service"
 & ".\$release.ps1" install
+if ($LASTEXITCODE -ne 0) {
+    Write-Error "Failed to install service"
+}
 ""
 
 "*** Start service"
 & ".\$release.ps1" start
+if ($LASTEXITCODE -ne 0) {
+    Write-Error "Failed to start service"
+}
 ""
 
 "*** Ping service"
 & ".\$release.ps1" ping
+if ($LASTEXITCODE -ne 0) {
+    Write-Error "Failed to ping service"
+}
 ""
 
 "*** Stop service"
 & ".\$release.ps1" stop
+if ($LASTEXITCODE -ne 0) {
+    Write-Error "Failed to stop service"
+}
 ""
 
 "*** Uninstall service"
 & ".\$release.ps1" uninstall
+if ($LASTEXITCODE -ne 0) {
+    Write-Error "Failed to uninstall service"
+}
 ""


### PR DESCRIPTION
Ensure we use file:del_dir() for directory symlinks on windows (while continuing to use file:delete() on other platforms).

Resolves #801 