### PR TITLE
Cosmetic change: Omit redundant foreground flag

### DIFF
--- a/priv/templates/extended_bin
+++ b/priv/templates/extended_bin
@@ -851,7 +851,7 @@ case "$1" in
                 else
                   BOOTFILE="$REL_DIR/start"
                 fi
-                FOREGROUNDOPTIONS="-noshell -noinput +Bd"
+                FOREGROUNDOPTIONS="-noinput +Bd"
                 ;;
             console_clean)
                 # if not set by user use interactive mode for console_clean

--- a/priv/templates/extended_bin_windows_ps
+++ b/priv/templates/extended_bin_windows_ps
@@ -341,7 +341,7 @@ function Foreground() {
     $env:ERL_LIBS = "$rootdir\lib"
 
     # Start the release in an `erl` shell
-    $params = @($erl_opts, '-boot', $boot_script, '-noshell', '-noinput', '+Bd')
+    $params = @($erl_opts, '-boot', $boot_script, '-noinput', '+Bd')
     if (![string]::IsNullOrEmpty($sys_config)) { $params += '-config', $sys_config }
     if (![string]::IsNullOrEmpty($vm_args))    { $params += '-args_file', $vm_args }
     & $erl $params

--- a/priv/templates/install_upgrade_escript
+++ b/priv/templates/install_upgrade_escript
@@ -1,5 +1,5 @@
 #!/usr/bin/env escript
-%%! -noshell -noinput
+%%! -noinput
 %% -*- mode: erlang;erlang-indent-level: 4;indent-tabs-mode: nil -*-
 %% ex: ft=erlang ts=4 sw=4 et
 


### PR DESCRIPTION
The `-noinput` flag [implies][1] `-noshell`, so specifying both will result in argument lists with duplicated `-noshell` flags.

[1]: https://github.com/erlang/otp/blob/OTP-23.0.2/erts/doc/src/erl_cmd.xml#L425-L428