### PR TITLE
Preserve the order of goals in rel file

### DIFF
--- a/src/rlx_resolve.erl
+++ b/src/rlx_resolve.erl
@@ -30,10 +30,14 @@ solve_release(Release, State0) ->
             erlang:error(?RLX_ERROR({no_goals_specified, {RelName, RelVsn}}));
         Goals ->
             LibDirs = rlx_state:lib_dirs(State1),
-            Pkgs = subset(maps:to_list(Goals), AllApps, LibDirs),
+            OrderedGoals = lists:sort(fun compare_goals/2, maps:to_list(Goals)),
+            Pkgs = subset(OrderedGoals, AllApps, LibDirs),
             Pkgs1 = remove_exclude_apps(Pkgs, State1),
             set_resolved(Release, Pkgs1, State1)
     end.
+
+compare_goals({_, #{index := IndexA}}, {_, #{index := IndexB}}) ->
+    IndexA < IndexB.
 
 %% find the app_info records for each application and its deps needed for the release
 subset(Apps, World, LibDirs) ->

--- a/test/rlx_release_SUITE.erl
+++ b/test/rlx_release_SUITE.erl
@@ -41,7 +41,7 @@ groups() ->
        make_exclude_modules_release, make_release_with_sys_config_vm_args_src,
        make_exclude_app_release, make_overridden_release, make_goalless_release,
        make_one_app_top_level_release, make_release_twice, make_erts_release,
-       make_erts_config_release, make_included_nodetool_release]},
+       make_erts_config_release, make_included_nodetool_release, make_release_goal_order]},
      {dev_mode, [shuffle], [make_dev_mode_template_release,
                             make_dev_mode_release,
                             make_release_twice_dev_mode]},
@@ -96,6 +96,22 @@ make_release(Config) ->
     ?assert(lists:member({goal_app_1, "0.0.1"}, AppSpecs)),
     ?assert(lists:member({goal_app_2, "0.0.1"}, AppSpecs)),
     ?assert(lists:member({lib_dep_1, "0.0.1", load}, AppSpecs)).
+
+make_release_goal_order(Config) ->
+  LibDir = ?config(lib_dir, Config),
+  OutputDir = ?config(out_dir, Config),
+
+  RelxConfig = [{release, {ordered_foo, "0.0.1"},
+    [goal_app_2, goal_app_1]}
+  ],
+
+  {ok, State} = relx:build_release(ordered_foo, [{root_dir, LibDir}, {lib_dirs, [LibDir]},
+    {output_dir, OutputDir} | RelxConfig]),
+
+  [{{ordered_foo, "0.0.1"}, Release}] = maps:to_list(rlx_state:realized_releases(State)),
+  AppSpecs = rlx_release:app_specs(Release),
+  ?assertMatch([{goal_app_2, "0.0.1"}, {goal_app_1, "0.0.1"} | _], AppSpecs).
+
 
 make_config_release(Config) ->
     DataDir = ?config(priv_dir, Config),


### PR DESCRIPTION
According to the systools documentation:

> The applications are sorted according to the dependencies between the applications. Where there are no dependencies, the order in the .rel file is kept.

This allows a certain level of control of the application start
sequence, which, unfortunately, is not available if one is to generate
releases using relx, due to the use of an unordered container (map) to
store release app goals.

Say, you have two applications, without any dependencies between them,
that you'd like to include in the same release. The release spec would
then look like: `{release, {my_release, "0.0.1"}, [b_app, a_app]}`.
Expectation is that, since there are no dependencies between them, b_app
would be first in the boot script, which is not the case due to the way
`maps:to_list/0` _currently_ works.

This change adds an extra field to the `parsed_goal()` map, which stores
the index of the goal in the original release specification. Goals order
is then restored according to this index value prior to generating the
.rel file. No other functionality is affected.