### PR TITLE
add check_for_undefined_functions option using xref on release

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -42,6 +42,7 @@
 
                 %% used in tests
                 {rlx_app_info, new, 5},
+                {rlx_app_info, new, 6},
                 {rlx_file_utils, type, 1},
                 {rlx_file_utils, write, 2},
                 {rlx_release, applications, 1},

--- a/src/rlx_app_info.erl
+++ b/src/rlx_app_info.erl
@@ -73,7 +73,7 @@
 
 -spec new(atom(), string(), file:name(), [atom()], [atom()]) -> t().
 new(Name, Vsn, Dir, Applications, IncludedApplications) ->
-    new(Name, Vsn, Dir, Applications, IncludedApplications, false).
+    new(Name, Vsn, Dir, Applications, IncludedApplications, dep).
 
 -spec new(atom(), string(), file:name(), [atom()], [atom()], app_type()) -> t().
 new(Name, Vsn, Dir, Applications, IncludedApplications, AppType) ->

--- a/src/rlx_app_info.erl
+++ b/src/rlx_app_info.erl
@@ -37,6 +37,7 @@
 -module(rlx_app_info).
 
 -export([new/5,
+         new/6,
          name/1,
          vsn/1,
          dir/1,
@@ -57,12 +58,18 @@
                included_applications := [atom()],
 
                dir                   := file:name() | undefined,
-               link                  := boolean() | undefined}.
+               link                  := boolean() | undefined,
+
+               is_project_app        := boolean()}.
 
 -export_type([t/0]).
 
 -spec new(atom(), string(), file:name(), [atom()], [atom()]) -> t().
 new(Name, Vsn, Dir, Applications, IncludedApplications) ->
+    new(Name, Vsn, Dir, Applications, IncludedApplications, false).
+
+-spec new(atom(), string(), file:name(), [atom()], [atom()], boolean()) -> t().
+new(Name, Vsn, Dir, Applications, IncludedApplications, IsProjectApp) ->
     #{name => Name,
       vsn => Vsn,
 
@@ -70,7 +77,9 @@ new(Name, Vsn, Dir, Applications, IncludedApplications) ->
       included_applications => IncludedApplications,
 
       dir => Dir,
-      link => false}.
+      link => false,
+
+      is_project_app => IsProjectApp}.
 
 -spec name(t()) -> atom().
 name(#{name := Name}) ->

--- a/src/rlx_app_info.erl
+++ b/src/rlx_app_info.erl
@@ -51,6 +51,7 @@
 
 -include("relx.hrl").
 
+-type app_type() :: project | dep | checkout | system.
 -type t() :: #{name                  := atom() | undefined,
                vsn                   := string() | undefined,
 
@@ -60,16 +61,22 @@
                dir                   := file:name() | undefined,
                link                  := boolean() | undefined,
 
-               is_project_app        := boolean()}.
+               %% `project' app is one the user is actively developing on
+               %% `dep' is dependency fetched by rebar3
+               %% `checkout' is a dependency linked to from the _checkouts dir
+               %% and treated like a project app
+               %% `system' applications are dependencies from Erlang/OTP
+               app_type              := app_type()}.
 
--export_type([t/0]).
+-export_type([t/0,
+              app_type/0]).
 
 -spec new(atom(), string(), file:name(), [atom()], [atom()]) -> t().
 new(Name, Vsn, Dir, Applications, IncludedApplications) ->
     new(Name, Vsn, Dir, Applications, IncludedApplications, false).
 
--spec new(atom(), string(), file:name(), [atom()], [atom()], boolean()) -> t().
-new(Name, Vsn, Dir, Applications, IncludedApplications, IsProjectApp) ->
+-spec new(atom(), string(), file:name(), [atom()], [atom()], app_type()) -> t().
+new(Name, Vsn, Dir, Applications, IncludedApplications, AppType) ->
     #{name => Name,
       vsn => Vsn,
 
@@ -79,7 +86,7 @@ new(Name, Vsn, Dir, Applications, IncludedApplications, IsProjectApp) ->
       dir => Dir,
       link => false,
 
-      is_project_app => IsProjectApp}.
+      app_type => AppType}.
 
 -spec name(t()) -> atom().
 name(#{name := Name}) ->

--- a/src/rlx_assemble.erl
+++ b/src/rlx_assemble.erl
@@ -643,7 +643,7 @@ maybe_check_for_undefined_functions(State, Release) ->
     end.
 
 maybe_check_for_undefined_functions_(State, Release) ->
-    xref:start(?XREF_SERVER, [{xref_mode, functions}]),
+    {ok, _} = xref:start(?XREF_SERVER, [{xref_mode, functions}]),
 
     %% for every app in the release add it to the xref apps to be analyzed if
     %% it is a project app as specified by rebar3.

--- a/src/rlx_assemble.erl
+++ b/src/rlx_assemble.erl
@@ -639,11 +639,11 @@ maybe_check_for_undefined_functions(State, Release) ->
         true ->
             maybe_check_for_undefined_functions_(State, Release);
         _ ->
-            false
+            ok
     end.
 
 maybe_check_for_undefined_functions_(State, Release) ->
-    {ok, _} = xref:start(?XREF_SERVER, [{xref_mode, functions}]),
+    xref:start(?XREF_SERVER, [{xref_mode, functions}]),
 
     %% for every app in the release add it to the xref apps to be analyzed if
     %% it is a project app as specified by rebar3.
@@ -673,7 +673,7 @@ add_project_apps_to_xref([], _) ->
     ok;
 add_project_apps_to_xref([AppSpec | Rest], State) ->
     case maps:find(element(1, AppSpec), rlx_state:available_apps(State)) of
-        {ok, App=#{is_project_app := true}} ->
+        {ok, App=#{app_type := project}} ->
             case xref:add_application(?XREF_SERVER,
                                       rlx_app_info:dir(App),
                                       [{name, rlx_app_info:name(App)}, {warnings, false}]) of

--- a/src/rlx_assemble.erl
+++ b/src/rlx_assemble.erl
@@ -6,6 +6,8 @@
 -include("relx.hrl").
 -include("rlx_log.hrl").
 
+-define(XREF_SERVER, rlx_xref).
+
 do(Release, State) ->
     RelName = rlx_release:name(Release),
     ?log_info("Assembling release ~p-~s...", [RelName, rlx_release:vsn(Release)]),
@@ -606,12 +608,17 @@ include_erts(State, Release, OutputDir, RelDir) ->
 
 -spec make_boot_script(rlx_state:t(), rlx_release:t(), file:name(), file:name()) -> ok.
 make_boot_script(State, Release, OutputDir, RelDir) ->
-    Options = [{path, [RelDir | rlx_util:get_code_paths(Release, OutputDir)]},
+    Paths = [RelDir | rlx_util:get_code_paths(Release, OutputDir)],
+    Options = [{path, Paths},
                {outdir, RelDir},
                {variables, make_boot_script_variables(Release, State)},
                silent | make_script_options(State)],
     Name = atom_to_list(rlx_release:name(Release)),
     IsRelxSasl = rlx_state:is_relx_sasl(State),
+
+    %% relx built in form of systools exref feature
+    maybe_check_for_undefined_functions(State, Release),
+
     case make_start_script(Name, RelDir, Options, IsRelxSasl) of
         Result when Result =:= ok orelse (is_tuple(Result) andalso
                                           element(1, Result) =:= ok) ->
@@ -626,6 +633,70 @@ make_boot_script(State, Release, OutputDir, RelDir) ->
         {error, Module, Error} ->
             erlang:error(?RLX_ERROR({release_script_generation_error, Module, Error}))
     end.
+
+maybe_check_for_undefined_functions(State, Release) ->
+    case rlx_state:check_for_undefined_functions(State) of
+        true ->
+            maybe_check_for_undefined_functions_(State, Release);
+        _ ->
+            false
+    end.
+
+maybe_check_for_undefined_functions_(State, Release) ->
+    {ok, _} = xref:start(?XREF_SERVER, [{xref_mode, functions}]),
+
+    %% for every app in the release add it to the xref apps to be analyzed if
+    %% it is a project app as specified by rebar3.
+    add_project_apps_to_xref(rlx_release:app_specs(Release), State),
+
+    %% without adding the erts application there will be warnings about missing
+    %% functions from the preloaded modules even though they are in the runtime.
+    ErtsApp = code:lib_dir(erts, ebin),
+
+    %% xref library path is what is searched for functions used by the project apps.
+    %% we only add applications depended on by the release so that we catch
+    %% modules not included in the release to warn the user about.
+    CodePath = [ErtsApp | [filename:join(rlx_app_info:dir(App), "ebin") ||
+                              App <- rlx_release:applications(Release)]],
+    _ = xref:set_library_path(?XREF_SERVER, CodePath),
+
+    %% check for undefined function calls from project apps in the release
+    case xref:analyze(?XREF_SERVER, undefined_function_calls) of
+        {ok, Warnings} ->
+            format_xref_warning(Warnings);
+        {error, _} = Error ->
+            ?log_warn("Error running xref analyze: ~s", [xref:format_error(Error)])
+    end,
+
+    xref:stop(?XREF_SERVER).
+add_project_apps_to_xref([], _) ->
+    ok;
+add_project_apps_to_xref([AppSpec | Rest], State) ->
+    case maps:find(element(1, AppSpec), rlx_state:available_apps(State)) of
+        {ok, App=#{is_project_app := true}} ->
+            case xref:add_application(?XREF_SERVER,
+                                      rlx_app_info:dir(App),
+                                      [{name, rlx_app_info:name(App)}, {warnings, false}]) of
+                {ok, _} ->
+                    ok;
+                {error, _} = Error ->
+                    ?log_warn("Error adding application ~s to xref context: ~s",
+                              [rlx_app_info:name(App), xref:format_error(Error)])
+            end;
+        _ ->
+            ok
+    end,
+    add_project_apps_to_xref(Rest, State).
+
+format_xref_warning([]) ->
+    ok;
+format_xref_warning(Warnings) ->
+    ?log_warn("There are missing function calls in the release.", []),
+    ?log_warn("Make sure all applications needed at runtime are included in the release.", []),
+    lists:map(fun({{M1, F1, A1}, {M2, F2, A2}}) ->
+                      ?log_warn("~w:~tw/~w calls undefined function ~w:~tw/~w",
+                                [M1, F1, A1, M2, F2, A2])
+              end, Warnings).
 
 %% setup options for warnings as errors, src_tests and exref
 make_script_options(State) ->

--- a/src/rlx_assemble.erl
+++ b/src/rlx_assemble.erl
@@ -616,7 +616,7 @@ make_boot_script(State, Release, OutputDir, RelDir) ->
     Name = atom_to_list(rlx_release:name(Release)),
     IsRelxSasl = rlx_state:is_relx_sasl(State),
 
-    %% relx built in form of systools exref feature
+    %% relx built-in form of systools exref feature
     maybe_check_for_undefined_functions(State, Release),
 
     case make_start_script(Name, RelDir, Options, IsRelxSasl) of

--- a/src/rlx_config.erl
+++ b/src/rlx_config.erl
@@ -115,6 +115,8 @@ load({src_tests, SrcTests}, {ok, State}) ->
     {ok, rlx_state:src_tests(State, SrcTests)};
 load({exref, ExRef}, {ok, State}) ->
     {ok, rlx_state:exref(State, ExRef)};
+load({check_for_undefined_functions, CheckForUndefinedFunctions}, {ok, State}) ->
+    {ok, rlx_state:check_for_undefined_functions(State, CheckForUndefinedFunctions)};
 load({include_erts, IncludeErts}, {ok, State}) ->
     {ok, rlx_state:include_erts(State, IncludeErts)};
 load({system_libs, SystemLibs}, {ok, State}) ->

--- a/src/rlx_state.erl
+++ b/src/rlx_state.erl
@@ -91,6 +91,8 @@
          src_tests/2,
          exref/1,
          exref/2,
+         check_for_undefined_functions/1,
+         check_for_undefined_functions/2,
          is_relx_sasl/1]).
 
 -type mode() :: dev | prod | minimal.
@@ -120,6 +122,7 @@
                   upfrom :: string() | binary() | undefined,
                   warnings_as_errors=false :: boolean(),
                   src_tests=true :: boolean(),
+                  check_for_undefined_functions=false :: boolean(),
                   exref=false :: boolean() | [atom()],
                   overlay=[] :: list(),
                   include_nodetool=true :: boolean(),
@@ -441,6 +444,14 @@ src_tests(#state_t{src_tests=SrcTests}) ->
 -spec src_tests(t(), boolean()) -> t().
 src_tests(State, SrcTests) ->
     State#state_t{src_tests=SrcTests}.
+
+-spec check_for_undefined_functions(t()) -> boolean().
+check_for_undefined_functions(#state_t{check_for_undefined_functions=CheckForUndefinedFunctions}) ->
+    CheckForUndefinedFunctions.
+
+-spec check_for_undefined_functions(t(), boolean()) -> t().
+check_for_undefined_functions(State, CheckForUndefinedFunctions) ->
+    State#state_t{check_for_undefined_functions=CheckForUndefinedFunctions}.
 
 -spec exref(t()) -> boolean() | [atom()].
 exref(#state_t{exref=ExRef}) ->

--- a/src/rlx_state.erl
+++ b/src/rlx_state.erl
@@ -122,7 +122,7 @@
                   upfrom :: string() | binary() | undefined,
                   warnings_as_errors=false :: boolean(),
                   src_tests=true :: boolean(),
-                  check_for_undefined_functions=false :: boolean(),
+                  check_for_undefined_functions=true :: boolean(),
                   exref=false :: boolean() | [atom()],
                   overlay=[] :: list(),
                   include_nodetool=true :: boolean(),

--- a/test/rlx_release_SUITE.erl
+++ b/test/rlx_release_SUITE.erl
@@ -82,7 +82,8 @@ make_release(Config) ->
                     goal_app_2]},
                   {release, {foo, "0.0.2"},
                    [goal_app_1,
-                    goal_app_2]}],
+                    goal_app_2]},
+                  {check_for_undefined_functions, false}],
 
     {ok, State} = relx:build_release(foo, [{root_dir, LibDir1}, {lib_dirs, [LibDir1]},
                                            {output_dir, OutputDir} | RelxConfig]),
@@ -102,11 +103,11 @@ make_release_goal_order(Config) ->
   OutputDir = ?config(out_dir, Config),
 
   RelxConfig = [{release, {ordered_foo, "0.0.1"},
-    [goal_app_2, goal_app_1]}
-  ],
+                 [goal_app_2, goal_app_1]},
+                  {check_for_undefined_functions, false}],
 
   {ok, State} = relx:build_release(ordered_foo, [{root_dir, LibDir}, {lib_dirs, [LibDir]},
-    {output_dir, OutputDir} | RelxConfig]),
+                                                 {output_dir, OutputDir} | RelxConfig]),
 
   [{{ordered_foo, "0.0.1"}, Release}] = maps:to_list(rlx_state:realized_releases(State)),
   AppSpecs = rlx_release:app_specs(Release),
@@ -129,6 +130,7 @@ make_config_release(Config) ->
                    [{goal_app_1, "0.0.2"},
                     goal_app_2],
                    [{some, config2}]},
+                  {check_for_undefined_functions, false},
                   {lib_dirs, [LibDir1]}],
 
     {ok, State} = relx:build_release(foo, [{root_dir, LibDir1}, {lib_dirs, [OtherAppsDir, LibDir1]},
@@ -178,6 +180,7 @@ make_extend_release_versioned(Config) ->
                     goal_app_2]},
                   {release, {foo_test, "0.0.3", {extend, {foo, "0.0.2"}}},
                    [goal_app_2]},
+                  {check_for_undefined_functions, false},
                   {lib_dirs, [filename:join(LibDir1, "*")]}],
 
     {ok, State} = relx:build_release(foo_test, [{root_dir, LibDir1}, {lib_dirs, [LibDir1]},
@@ -202,6 +205,7 @@ make_extend_config_release(Config) ->
                   {release, {foo_test, "0.0.1", {extend, foo}},
                    [goal_app_2],
                    [{some, config}]},
+                  {check_for_undefined_functions, false},
                   {lib_dirs, [filename:join(LibDir1, "*")]}],
 
     {ok, State} = relx:build_release(foo_test, [{root_dir, LibDir1}, {lib_dirs, [LibDir1]},
@@ -224,7 +228,8 @@ make_scriptless_release(Config) ->
     RelxConfig = [{generate_start_script, false},
                   {release, {foo, "0.0.1"},
                    [goal_app_1,
-                    goal_app_2]}],
+                    goal_app_2]},
+                  {check_for_undefined_functions, false}],
 
     {ok, State} = relx:build_release(foo, [{root_dir, LibDir1}, {lib_dirs, [LibDir1]},
                                            {output_dir, OutputDir} | RelxConfig]),
@@ -259,7 +264,8 @@ make_overridden_release(Config) ->
                    [goal_app_1,
                     OverrideAppName,
                     goal_app_2]},
-                  {dev_mode, true}],
+                  {dev_mode, true},
+                  {check_for_undefined_functions, false}],
 
     {ok, State} = relx:build_release(foo, [{root_dir, LibDir}, {lib_dirs, [OverrideDir1, LibDir]},
                                            {output_dir, OutputDir} | RelxConfig]),
@@ -291,7 +297,8 @@ make_exclude_app_release(Config) ->
 
     RelxConfig = [{release, {foo, "0.0.1"},
                    [goal_app_1]},
-                  {exclude_apps, [non_goal_1]}],
+                  {exclude_apps, [non_goal_1]},
+                  {check_for_undefined_functions, false}],
 
     {ok, State} = relx:build_release(foo, [{root_dir, LibDir1}, {lib_dirs, [LibDir1]},
                                            {output_dir, OutputDir} | RelxConfig]),
@@ -308,7 +315,8 @@ make_app_type_none_release(Config) ->
     OutputDir = ?config(out_dir, Config),
     RelxConfig = [{release, {foo, "0.0.1"},
                    [goal_app_1,
-                    {goal_app_2, none}]}],
+                    {goal_app_2, none}]},
+                  {check_for_undefined_functions, false}],
 
     {ok, State} = relx:build_release(foo, [{root_dir, LibDir1}, {lib_dirs, [LibDir1]},
                                            {output_dir, OutputDir} | RelxConfig]),
@@ -357,7 +365,8 @@ overlay_release(Config) ->
                              {copy, "{{erts_dir}}/bin/erl", "bin/copy.erl"}]},
                   {release, {foo, "0.0.1"},
                    [goal_app_1,
-                    goal_app_2]}],
+                    goal_app_2]},
+                  {check_for_undefined_functions, false}],
 
     VarsFile1 = filename:join([LibDir1, "vars1.config"]),
     %% `tpl_var' is defined in vars1, but redifined in vars2 using template.
@@ -474,7 +483,8 @@ make_goalless_release(Config) ->
     LibDir1 = ?config(lib_dir, Config),
     OutputDir = ?config(out_dir, Config),
     RelxConfig = [{release, {foo, "0.0.1"},
-                   []}],
+                   []},
+                  {check_for_undefined_functions, false}],
 
     ?assertError({error, {rlx_resolve, {no_goals_specified, {foo, "0.0.1"}}}},
                  relx:build_release(foo, [{root_dir, LibDir1}, {lib_dirs, [LibDir1]},
@@ -489,7 +499,8 @@ make_one_app_top_level_release(Config) ->
     %% Use non_goal_2 here because this is to test when a top level app
     %% has no dependencies of its own
     RelxConfig = [{release, {foo, "0.0.1"},
-                   [{non_goal_2, "0.0.1"}]}],
+                   [{non_goal_2, "0.0.1"}]},
+                  {check_for_undefined_functions, false}],
 
     {ok, State} = relx:build_release(foo, [{root_dir, LibDir1}, {lib_dirs, [LibDir1]},
                                            {output_dir, OutputDir} | RelxConfig]),
@@ -515,7 +526,8 @@ make_dev_mode_release(Config) ->
                   {vm_args, VmArgs},
                   {release, {foo, "0.0.1"},
                    [goal_app_1,
-                    goal_app_2]}],
+                    goal_app_2]},
+                  {check_for_undefined_functions, false}],
 
     {ok, State} = relx:build_release(foo, [{root_dir, LibDir1}, {lib_dirs, [LibDir1]},
                                            {output_dir, OutputDir} | RelxConfig]),
@@ -573,7 +585,8 @@ make_dev_mode_template_release(Config) ->
                               "releases/{{release_version}}/vm.args"}]},
                   {release, {foo, "0.0.1"},
                    [goal_app_1,
-                    goal_app_2]}],
+                    goal_app_2]},
+                  {check_for_undefined_functions, false}],
 
 
     {ok, State} = relx:build_release(foo, [{root_dir, LibDir1}, {lib_dirs, [LibDir1]},
@@ -605,7 +618,8 @@ make_release_twice(Config) ->
 
     RelxConfig = [{release, {foo, "0.0.1"},
                    [goal_app_1,
-                    goal_app_2]}],
+                    goal_app_2]},
+                  {check_for_undefined_functions, false}],
 
     {ok, State1} = relx:build_release(foo, [{root_dir, LibDir1}, {lib_dirs, [OtherAppsDir, LibDir1]},
                                             {output_dir, OutputDir} | RelxConfig]),
@@ -646,7 +660,8 @@ make_release_twice_dev_mode(Config) ->
     RelxConfig = [{release, {foo, "0.0.1"},
                    [goal_app_1,
                     goal_app_2]},
-                  {dev_mode, true}],
+                  {dev_mode, true},
+                  {check_for_undefined_functions, false}],
 
     {ok, State} = relx:build_release(foo, [{root_dir, LibDir1}, {lib_dirs, [OtherAppsDir, LibDir1]},
                                            {output_dir, OutputDir} | RelxConfig]),
@@ -681,7 +696,8 @@ make_erts_release(Config) ->
 
     ErtsVsn = erlang:system_info(version),
     RelxConfig = [{release, {foo, "0.0.1"}, {erts, ErtsVsn},
-                   [goal_app_1]}],
+                   [goal_app_1]},
+                  {check_for_undefined_functions, false}],
 
     {ok, State} = relx:build_release(foo, [{root_dir, LibDir1}, {lib_dirs, [LibDir1]},
                                            {output_dir, OutputDir} | RelxConfig]),
@@ -699,7 +715,8 @@ make_erts_config_release(Config) ->
     ErtsVsn = erlang:system_info(version),
     RelxConfig = [{release, {foo, "0.0.1"}, {erts, ErtsVsn},
                    [goal_app_1],
-                   [{some, config}]}],
+                   [{some, config}]},
+                  {check_for_undefined_functions, false}],
 
     {ok, State} = relx:build_release(foo, [{root_dir, LibDir1}, {lib_dirs, [LibDir1]},
                                            {output_dir, OutputDir} | RelxConfig]),
@@ -719,7 +736,8 @@ make_included_nodetool_release(Config) ->
     RelxConfig = [{release, {foo, "0.0.1"}, {erts, ErtsVsn},
                    [goal_app_1]},
                   {extended_start_script, true},
-                  {include_nodetool, true}],
+                  {include_nodetool, true},
+                  {check_for_undefined_functions, false}],
 
     {ok, State} = relx:build_release(foo, [{root_dir, LibDir1}, {lib_dirs, [LibDir1]},
                                            {output_dir, OutputDir} | RelxConfig]),
@@ -739,7 +757,8 @@ make_not_included_nodetool_release(Config) ->
     RelxConfig = [{release, {foo, "0.0.1"}, {erts, ErtsVsn},
                    [goal_app_1]},
                   {extended_start_script, true},
-                  {include_nodetool, false}],
+                  {include_nodetool, false},
+                  {check_for_undefined_functions, false}],
 
     {ok, State} = relx:build_release(foo, [{root_dir, LibDir1}, {lib_dirs, [LibDir1]},
                                            {output_dir, OutputDir} | RelxConfig]),
@@ -762,7 +781,8 @@ make_src_release(Config) ->
                    [goal_app_1]},
                   {extended_start_script, true},
                   {include_erts, true},
-                  {include_src, true}],
+                  {include_src, true},
+                  {check_for_undefined_functions, false}],
 
 
     {ok, State} = relx:build_release(foo, [{root_dir, LibDir1}, {lib_dirs, [LibDir1]},
@@ -785,7 +805,8 @@ make_excluded_src_release(Config) ->
                    [goal_app_1]},
                   {extended_start_script, true},
                   {include_erts, true},
-                  {include_src, false}],
+                  {include_src, false},
+                  {check_for_undefined_functions, false}],
 
     {ok, State} = relx:build_release(foo, [{root_dir, LibDir1}, {lib_dirs, [LibDir1]},
                                            {output_dir, OutputDir} | RelxConfig]),
@@ -853,7 +874,8 @@ make_release_with_sys_config_vm_args_src(Config) ->
                   {vm_args_src, VmArgsSrc},
                   {release, {foo, "0.0.1"},
                    [goal_app_1,
-                    goal_app_2]}],
+                    goal_app_2]},
+                  {check_for_undefined_functions, false}],
 
     {ok, State} = relx:build_release(foo, [{root_dir, LibDir1}, {lib_dirs, [LibDir1]},
                                            {output_dir, OutputDir} | RelxConfig]),
@@ -908,7 +930,8 @@ make_prod_mode_release(Config) ->
                   {vm_args, VmArgs},
                   {release, {foo, "0.0.1"},
                    [goal_app_1,
-                    goal_app_2]}],
+                    goal_app_2]},
+                  {check_for_undefined_functions, false}],
 
     {ok, State} = relx:build_release(foo, [{root_dir, LibDir1}, {lib_dirs, [LibDir1]},
                                            {output_dir, OutputDir} | RelxConfig]),
@@ -955,7 +978,8 @@ make_minimal_mode_release(Config) ->
                   {vm_args, VmArgs},
                   {release, {foo, "0.0.1"},
                    [goal_app_1,
-                    goal_app_2]}],
+                    goal_app_2]},
+                  {check_for_undefined_functions, false}],
 
     {ok, State} = relx:build_release(foo, [{root_dir, LibDir1}, {lib_dirs, [LibDir1]},
                                            {output_dir, OutputDir} | RelxConfig]),


### PR DESCRIPTION
`systools` `exref` feature has no good way of setting the `xref` library path so I've added our own feature for this. A use can still enable `exref` if they desire but in docs we will focus on this new option.

It only adds project apps that are in the release (even if they are not listed directly but are a dependency of another project app listed in the relx release applications list) and sets the library path to only include applications in the release.

This is important for helping catch when a user forgets to include an application in the release that is used -- like forgetting to add a runtime dependency to `.app.src` .

Question I want considered before we merge this: Should it be on by default?

I'm learning towards making it on by default.

Future work that should be done:

* Option to include non-OTP dependencies in the analysis. Main reason to always leave out OTP apps is stuff like `sasl` that has calls applications it doesn't depend on (the `tools` app).
* Option to exclude specific apps or warnings from the analysis. Example of the need for this is if the user wants to use the future "all dependencies" option and have a dep like `elli` that calls `ssl` but doesn't depend on it since the user doesn't have to use the ssl feature.
* Update the `systools` `exref` feature to make this being in `relx` no longer needed.