### PR TITLE
nodetool rpc: add dot at the end if its missing to match erl_call

### DIFF
--- a/priv/templates/nodetool
+++ b/priv/templates/nodetool
@@ -155,7 +155,14 @@ consult([]) ->
 consult(Bin) when is_binary(Bin)->
     consult(binary_to_list(Bin));
 consult(Str) when is_list(Str) ->
-    case erl_scan:string(Str) of
+    %% add '.' if the string doesn't end in one
+    Normalized =
+        case lists:reverse(Str) of
+            [$. | _] -> Str;
+            R -> lists:reverse([$. | R])
+        end,
+
+    case erl_scan:string(Normalized) of
         {ok, Tokens, _} ->
             case erl_parse:parse_term(Tokens) of
                 {ok, Args} ->

--- a/shelltests/extended_start_script_tests/extended_start_script_tests.tests
+++ b/shelltests/extended_start_script_tests/extended_start_script_tests.tests
@@ -55,6 +55,18 @@ $ ./_build/default/rel/replace_os_vars_tests/bin/replace_os_vars_tests eval '{ok
 "101"
 >= 0
 
+# rpc works with and without dot at the end of arguments
+$ ./_build/default/rel/replace_os_vars_tests/bin/replace_os_vars_tests rpc application get_env "[replace_os_vars_tests, var1, ok]"
+>
+"101"
+>= 0
+
+# rpc works with and without dot at the end of arguments
+$ ./_build/default/rel/replace_os_vars_tests/bin/replace_os_vars_tests rpc application get_env "[replace_os_vars_tests, var1, ok]."
+>
+"101"
+>= 0
+
 $ ./_build/default/rel/replace_os_vars_tests/bin/replace_os_vars_tests eval '{ok, V} = application:get_env(replace_os_vars_tests, baz), V.'
 >
 "bat zing"


### PR DESCRIPTION
This finishes up issue https://github.com/erlware/relx/issues/805 so nodetool acts the same as `erl_call`.