### PR TITLE
Tidy semver cleanup regexs and types

### DIFF
--- a/src/rlx_config.erl
+++ b/src/rlx_config.erl
@@ -225,7 +225,7 @@ get_patch_count(RawRef) ->
 build_vsn_string(Vsn, RawRef, RawCount) ->
     %% Cleanup the tag and the Ref information. Basically leading 'v's and
     %% whitespace needs to go away.
-    RefTag = [".ref", re:replace(RawRef, "\\W", "", [global])],
+    RefTag = [".ref", re:replace(RawRef, "\\s", "", [global])],
     Count = re:replace(RawCount, "\\D", "", [global]),
 
     %% Create the valid [semver](http://semver.org) version from the tag

--- a/src/rlx_config.erl
+++ b/src/rlx_config.erl
@@ -225,20 +225,20 @@ get_patch_count(RawRef) ->
 build_vsn_string(Vsn, RawRef, RawCount) ->
     %% Cleanup the tag and the Ref information. Basically leading 'v's and
     %% whitespace needs to go away.
-    RefTag = [".ref", re:replace(RawRef, "\\s", "", [global])],
-    Count = re:replace(RawCount, "\\s", "", [global]),
+    RefTag = [".ref", re:replace(RawRef, "\\W", "", [global])],
+    Count = re:replace(RawCount, "\\D", "", [global]),
 
     %% Create the valid [semver](http://semver.org) version from the tag
-    case Count of
+    case iolist_to_binary(Count) of
         <<"0">> ->
             lists:flatten(Vsn);
-        _ ->
-            lists:flatten([Vsn, "+build.", Count, RefTag])
+        CountBin ->
+            binary_to_list(iolist_to_binary([Vsn, "+build.", CountBin, RefTag]))
     end.
 
 parse_tags() ->
     Tag = rlx_util:sh("git describe --abbrev=0 --tags"),
-    Vsn = rlx_string:trim(rlx_string:trim(Tag, leading, "v"), leading, "\n"),
+    Vsn = rlx_string:trim(rlx_string:trim(Tag, leading, "v"), trailing, "\n"),
     {Tag, Vsn}.
 
 


### PR DESCRIPTION
Last release support for semver was broken, this commit addresses the issue by
- Restricting the available charsets in the semver cleanup regex
- Transforming the `iodata()` from `re:replace/2` to `binary()`
- Fixing removal of trailing newlines.