### PR TITLE
Unquote START_EPMD variable in extended_bin

### DIFF
--- a/priv/templates/extended_bin
+++ b/priv/templates/extended_bin
@@ -250,7 +250,7 @@ relx_get_nodename() {
                       -mode interactive \
                       -boot_var SYSTEM_LIB_DIR "$SYSTEM_LIB_DIR" \
                       -eval '[_,H]=re:split(atom_to_list(node()),"@",[unicode,{return,list}]), io:format("~s~n",[H]), halt()' \
-                      "${START_EPMD}" \
+                      ${START_EPMD} \
                       -noshell "${NAME_TYPE}" "$id"
     else
         # running with setcookie prevents a ~/.erlang.cookie from being created
@@ -259,7 +259,7 @@ relx_get_nodename() {
                       -boot_var SYSTEM_LIB_DIR "$SYSTEM_LIB_DIR" \
                       -eval '[_,H]=re:split(atom_to_list(node()),"@",[unicode,{return,list}]), io:format("~s~n",[H]), halt()' \
                       -setcookie "${COOKIE}" \
-                      "${START_EPMD}" \
+                      ${START_EPMD} \
                       -noshell "${NAME_TYPE}" "$id"
     fi
 }


### PR DESCRIPTION
"${START_EPMD}" after an -eval flag is interpreted as
-eval "foo" ""
if the variable is empty, causing startup to fail:

Note the `''` after the eval
```
++ /usr/local/lib/erlang/erts-10.7.2.3/bin/erl -boot /source/_build/default/rel/noproject/releases/noversion/start_clean -mode interactive -boot_var SYSTEM_LIB_DIR /usr/local/lib/erlang/lib -eval '[_,H]=re:split(atom_to_list(node()),"@",[unicode,{return,list}]), io:format("~s~n",[H]), halt()' '' -noshell -sname longname601049ce-
System process <0.0.0> terminated: {function_clause,[{init,prepare_run_args,[{eval,[<<"[_,H]=re:split(atom_to_list(node()),\"@\",[unicode,{return,list}]), io:format(\"~s~n\",[H]), halt()">>,<<>>]}],[]},{init,map,2,[]},{init,boot,1,[]}]}
(no logger present) unexpected logger message: {log,error,"Error in process ~p with exit value:~n~p~n",[<0.0.0>,{function_clause,[{init,prepare_run_args,[{eval,[<<"[_,H]=re:split(atom_to_list(node()),\"@\",[unicode,{return,list}]), io:format(\"~s~n\",[H]), halt()">>,<<>>]}],[]},{init,map,2,[]},{init,boot,1,[]}]}],#{error_logger=>#{emulator=>true,tag=>error},gl=><0.0.0>,pid=><0.0.0>,time=>1598997377363474}}
```