### PR TITLE
Fix file link error when shell language is not english

### DIFF
--- a/src/rlx_file_utils.erl
+++ b/src/rlx_file_utils.erl
@@ -163,11 +163,15 @@ win32_make_junction_cmd(Source, Target) ->
     case os:cmd(Cmd) of
         "Junction created " ++ _ ->
             ok;
-        [] ->
-            % When mklink fails it prints the error message to stderr which
-            % is not picked up by os:cmd() hence this case switch is for
-            % an empty message
-            cp_r(Source, Target)
+        _ ->
+            % When not English output, success out will not match, so just recheck link target
+            % if target is source, then also do nothing
+            case file:read_link(Target) of
+                {ok, Source} ->
+                    ok;
+                _ ->
+                    cp_r(Source, Target)
+            end
     end.
 
 -spec copy(file:name(), file:name()) -> ok | {error, term()}.


### PR DESCRIPTION
when shell language is not English, file link match will failed.
https://github.com/erlware/relx/blob/90167d1cb9a48170eaab4ee8c8d796b1fce36c9e/src/rlx_file_utils.erl#L162-L170
like this in rebar3 https://github.com/erlang/rebar3/issues/2371#issue-708685631,
and when use `rebar3 release` on windows and not english shell, it will fails.
so may be recheck link target when not match English output is a better way than force copy