### PR TITLE
Embedded specific fixes

### DIFF
--- a/priv/templates/builtin_hook_pid
+++ b/priv/templates/builtin_hook_pid
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # loop until the VM starts responding to pings
 while ! erl_rpc erlang is_alive > /dev/null

--- a/priv/templates/builtin_hook_status
+++ b/priv/templates/builtin_hook_status
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/bin/sh
 
 erl_eval "application:which_applications()."

--- a/priv/templates/builtin_hook_wait_for_process
+++ b/priv/templates/builtin_hook_wait_for_process
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # loop until the VM starts responding to pings
 while ! erl_rpc erlang is_alive > /dev/null

--- a/priv/templates/builtin_hook_wait_for_vm_start
+++ b/priv/templates/builtin_hook_wait_for_vm_start
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # loop until the VM starts responding to pings
 while ! erl_rpc erlang is_alive > /dev/null

--- a/priv/templates/extended_bin
+++ b/priv/templates/extended_bin
@@ -337,7 +337,7 @@ erl_eval() {
 
 # Generate a random id
 relx_gen_id() {
-    od -t x -N 4 /dev/urandom | head -n1 | awk '{print $2}'
+    dd count=1 bs=4 if=/dev/urandom 2> /dev/null | od -x  | head -n1 | awk '{print $2$3}'
 }
 
 # Control a node with nodetool if erl_call isn't from OTP-23+


### PR DESCRIPTION
Hi there

These two commits are necessary in order to run relx builtin_hooks and extended_bin scripts when the target platform doesn't provide `bash` and relies on busybox utilities.

* use `sh` instead of `bash`
* call `dd` when reading _/dev/urandom_ and use common `od` options (supported by busybox and GNU utils)

Please, feel free to close this PR if it is very embedded specific use case.

Thanks.