### PR TITLE
updates to start script for otp 23.1

### DIFF
--- a/.github/workflows/shelltest.yml
+++ b/.github/workflows/shelltest.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         # important to check a pre-23 version that still uses nodetool
         # plus 23 once it is released
-        otp_version: [23.1]
+        otp_version: [22.3.2, 23.1]
         os: [ubuntu-latest]
 
     steps:

--- a/.github/workflows/shelltest.yml
+++ b/.github/workflows/shelltest.yml
@@ -3,11 +3,9 @@ name: ShellTestRunner
 on:
   pull_request:
     branches:
-      - '4.0.0'
       - 'master'
   push:
     branches:
-      - '4.0.0'
       - 'master'
 
 jobs:
@@ -19,7 +17,7 @@ jobs:
       matrix:
         # important to check a pre-23 version that still uses nodetool
         # plus 23 once it is released
-        otp_version: [22.3.2]
+        otp_version: [23.1]
         os: [ubuntu-latest]
 
     steps:

--- a/priv/templates/extended_bin
+++ b/priv/templates/extended_bin
@@ -318,7 +318,7 @@ erl_rpc() {
             fi
             code=$?
             if [ $code -eq 0 ]; then
-                echo "$result" | tr -d "\n"
+                echo "$result"
             else
                 return $code
             fi
@@ -337,7 +337,7 @@ erl_eval() {
             result=$(echo "${command}" | "$ERL_RPC" "$NAME_TYPE" "$NAME" -R -timeout "${RELX_RPC_TIMEOUT}" -c "${COOKIE}" -e)
             code=$?
             if [ $code -eq 0 ]; then
-                echo "$result" | sed 's/^{ok, \(.*\)}$/\1/' | tr -d "\n"
+                echo "$result" | sed 's/^{ok, \(.*\)}$/\1/'
             else
                 return $code
             fi

--- a/priv/templates/extended_bin
+++ b/priv/templates/extended_bin
@@ -226,7 +226,7 @@ find_erl_call() {
 
 # Get node pid
 relx_get_pid() {
-    if output="$(erl_rpc os getpid)"
+    if output="$(erl_rpc os getpid 2>/dev/null)"
     then
         echo "$output" | sed -e 's/"//g'
         return 0
@@ -749,7 +749,7 @@ case "$1" in
         relx_run_hooks "$PRE_STOP_HOOKS"
         # Wait for the node to completely stop...
         PID="$(relx_get_pid)"
-        if ! erl_rpc init stop > /dev/null; then
+        if ! erl_rpc init stop > /dev/null 2>&1; then
             exit 1
         fi
         while kill -s 0 "$PID" 2>/dev/null;

--- a/priv/templates/extended_bin
+++ b/priv/templates/extended_bin
@@ -269,9 +269,13 @@ relx_rem_sh() {
     # Remove remote_nodename when OTP-23 is the oldest version supported by rebar3/relx.
     # sort the used erts version against 11.0 to see if it is less than 11.0 (OTP-23)
     # if it is then we must generate a node name to use for the remote node.
-    # But this feature is only for short names. So first check if `NAME_TYPE` is `sname`
+    # But this feature is only for short names in 23.0 (erts 11.0). It can be used
+    # for long names with 23.1 (erts 11.1) and above.
     if [ "${NAME_TYPE}" = "-sname" ] && [  "11.0" = "$(printf "%s\n11.0" "${ERTS_VSN}" | sort -V | head -n1)" ] ; then
-        # OTP-16616: erl -remsh now uses the dynamic node names feature by default
+
+        remote_nodename="${NAME_TYPE} undefined"
+    # if the name type is longnames then make sure this is erts 11.1+
+    elif [ "${NAME_TYPE}" = "-name" ] && [  "11.1" = "$(printf "%s\n11.1" "${ERTS_VSN}" | sort -V | head -n1)" ] ; then
         remote_nodename="${NAME_TYPE} undefined"
     else
         # Generate a unique id used to allow multiple remsh to the same node transparently
@@ -300,10 +304,17 @@ erl_rpc() {
         *)
             command=$*
 
-            if [ "$ERL_DIST_PORT" ]; then
-                result=$("$ERL_RPC" -r -c "${COOKIE}" -address "${ERL_DIST_PORT}"  -timeout "${RELX_RPC_TIMEOUT}" -a "${command}")
+            # erl_call -R is recommended for generating dynamic node name but is only available in 23.0+
+            if [  "11.0" = "$(printf "%s\n11.0" "${ERTS_VSN}" | sort -V | head -n1)" ] ; then
+                DYNAMIC_NAME="-R"
             else
-                result=$("$ERL_RPC" "$NAME_TYPE" "$NAME" -R -c "${COOKIE}" -timeout "${RELX_RPC_TIMEOUT}" -a "${command}")
+                DYNAMIC_NAME="-r"
+            fi
+
+            if [ "$ERL_DIST_PORT" ]; then
+                result=$("$ERL_RPC" "${DYNAMIC_NAME}" -c "${COOKIE}" -address "${ERL_DIST_PORT}"  -timeout "${RELX_RPC_TIMEOUT}" -a "${command}")
+            else
+                result=$("$ERL_RPC" "$NAME_TYPE" "$NAME" "${DYNAMIC_NAME}" -c "${COOKIE}" -timeout "${RELX_RPC_TIMEOUT}" -a "${command}")
             fi
             code=$?
             if [ $code -eq 0 ]; then
@@ -642,7 +653,16 @@ if [ "$EPMD_MODULE" ]; then
 fi
 
 if [ "$ERL_DIST_PORT" ]; then
-    MAYBE_DIST_ARGS="${MAYBE_DIST_ARGS} -kernel inet_dist_listen_min ${ERL_DIST_PORT} -kernel inet_dist_listen_max ${ERL_DIST_PORT}"
+    if [  "11.1" = "$(printf "%s\n11.1" "${ERTS_VSN}" | sort -V | head -n1)" ] ; then
+        # unless set by the user, set start_epmd to false when ERL_DIST_PORT is used
+        if [ ! "$START_EPMD" ]; then
+            MAYBE_DIST_ARGS="${MAYBE_DIST_ARGS} -erl_epmd_port ${ERL_DIST_PORT} -start_epmd false"
+        else
+            MAYBE_DIST_ARGS="${MAYBE_DIST_ARGS} -erl_epmd_port ${ERL_DIST_PORT}"
+        fi
+    else
+        MAYBE_DIST_ARGS="${MAYBE_DIST_ARGS} -kernel inet_dist_listen_min ${ERL_DIST_PORT} -kernel inet_dist_listen_max ${ERL_DIST_PORT}"
+    fi
 fi
 
 # Extract the target cookie
@@ -885,7 +905,8 @@ case "$1" in
             -boot "$BOOTFILE" -mode "$CODE_LOADING_MODE" \
             -boot_var SYSTEM_LIB_DIR "$SYSTEM_LIB_DIR" \
             -config "$RELX_CONFIG_PATH" \
-            -args_file "$VMARGS_PATH" -- "$@"
+            -args_file "$VMARGS_PATH" \
+            $MAYBE_DIST_ARGS -- "$@"
         echo "Root: $ROOTDIR"
 
         # Log the startup
@@ -900,7 +921,8 @@ case "$1" in
             -boot "$BOOTFILE" -mode "$CODE_LOADING_MODE" \
             -boot_var SYSTEM_LIB_DIR "$SYSTEM_LIB_DIR" \
             -config "$RELX_CONFIG_PATH" \
-            -args_file "$VMARGS_PATH" -- "$@"
+            -args_file "$VMARGS_PATH" \
+            $MAYBE_DIST_ARGS -- "$@"
         # exec will replace the current image and nothing else gets
         # executed from this point on, this explains the absence
         # of the pre start hook

--- a/shelltests/extended_start_script_tests/extended_start_script_tests.tests
+++ b/shelltests/extended_start_script_tests/extended_start_script_tests.tests
@@ -142,10 +142,17 @@ $ NODETOOL_TIMEOUT=foo ./_build/default/rel/replace_os_vars_tests/bin/replace_os
 $ ./_build/default/rel/replace_os_vars_tests/bin/replace_os_vars_tests stop
 >= 0
 
+# we run these tests only on 23.1 so we can test that ERL_DIST_PORT causes epmd to not start
+$ pkill epmd
+
 $ ERL_DIST_PORT=8001 ./_build/default/rel/replace_os_vars_tests/bin/replace_os_vars_tests daemon
 
 $ sleep 1
 >= 0
+
+# verify epmd isn't running
+$ pidof epmd
+>= 1
 
 $ ERL_DIST_PORT=8001 ./_build/default/rel/replace_os_vars_tests/bin/replace_os_vars_tests ping
 >

--- a/shelltests/extended_start_script_tests/extended_start_script_tests.tests
+++ b/shelltests/extended_start_script_tests/extended_start_script_tests.tests
@@ -141,3 +141,16 @@ $ NODETOOL_TIMEOUT=foo ./_build/default/rel/replace_os_vars_tests/bin/replace_os
 
 $ ./_build/default/rel/replace_os_vars_tests/bin/replace_os_vars_tests stop
 >= 0
+
+$ ERL_DIST_PORT=8001 ./_build/default/rel/replace_os_vars_tests/bin/replace_os_vars_tests daemon
+
+$ sleep 1
+>= 0
+
+$ ERL_DIST_PORT=8001 ./_build/default/rel/replace_os_vars_tests/bin/replace_os_vars_tests ping
+>
+pong
+>= 0
+
+$ ERL_DIST_PORT=8001 ./_build/default/rel/replace_os_vars_tests/bin/replace_os_vars_tests stop
+>= 0

--- a/shelltests/run_tests.sh
+++ b/shelltests/run_tests.sh
@@ -22,4 +22,4 @@ sed -i 's_relx\(.*\)build/default/lib/_relx\1checkouts_' rebar.config
 
 popd
 
-PATH="${rebar3_dir}":~/.cabal/bin/:$PATH shelltest -c --diff --all --debug --execdir -- */*.test
+PATH="${rebar3_dir}":~/.cabal/bin/:$PATH shelltest -c --diff --all --execdir -- */*.test


### PR DESCRIPTION
If erts 11.1 or above is used then `undefined` is to be used for
the longname in remsh. This results in a generated node name.

When ERL_DIST_PORT is set and no start_epmd argument is found in
the vm args file and the erts is 11.1 or newer then add start_epmd
false to the dist args automatically.

This means on the latest Erlang the user needs to only set
ERL_DIST_PORT to get a static port for the node and disable epmd.