### PR TITLE
Bring back undocumented start/attach extended start script commands

### DIFF
--- a/priv/templates/extended_bin
+++ b/priv/templates/extended_bin
@@ -702,7 +702,7 @@ cd "$ROOTDIR"
 
 # Check the first argument for instructions
 case "$1" in
-    daemon|daemon_boot)
+    start|daemon|daemon_boot)
         case "$1" in
             daemon)
                 shift
@@ -713,6 +713,15 @@ case "$1" in
                 shift
                 START_OPTION="console_boot"
                 HEART_OPTION="daemon_boot"
+                ;;
+            start)
+                # TODO, add here the right annoying message asking users to consider
+                # instead using systemd or some such other init system
+                echo "'start' has been deprecated, replaced by 'daemon' and will be removed in the short-term, please consult rebar3.org on why you should be"\
+                     "using 'foreground' and an init tool such as 'systemd'"
+                shift
+                START_OPTION="console"
+                HEART_OPTION="daemon"
                 ;;
         esac
 
@@ -802,7 +811,15 @@ case "$1" in
         fi
         ;;
 
-    daemon_attach)
+    daemon_attach|attach)
+        case "$1" in
+            attach)
+                # TODO, add here the right annoying message asking users to consider
+                # instead using systemd or some such other init system
+                echo "'attach' has been deprecated, replaced by 'daemon_attach' and will be removed in the short-term, please consult rebar3.org on why you should be"\
+                     "using 'foreground' and an init tool such as 'systemd'"
+                ;;
+        esac
         # Make sure a node IS running
         ping_or_exit
 

--- a/shelltests/extended_start_script_tests/extended_start_script_tests.tests
+++ b/shelltests/extended_start_script_tests/extended_start_script_tests.tests
@@ -161,3 +161,17 @@ pong
 
 $ ERL_DIST_PORT=8001 ./_build/default/rel/replace_os_vars_tests/bin/replace_os_vars_tests stop
 >= 0
+
+$ ./_build/default/rel/replace_os_vars_tests/bin/replace_os_vars_tests start
+
+$ sleep 1
+>= 0
+
+$ ./_build/default/rel/replace_os_vars_tests/bin/replace_os_vars_tests ping
+>
+pong
+>= 0
+
+$ ./_build/default/rel/replace_os_vars_tests/bin/replace_os_vars_tests stop
+>= 0
+


### PR DESCRIPTION
Prints out an annoying message instructing users to consider the
alternatives while still supporting these operations. Main intent
is to ease adoption of a new version and not force people to go around
changing millions of scripts from 'start' to 'daemon'.