### PR TITLE
disable html escaping in overlay templates

### DIFF
--- a/src/rlx_util.erl
+++ b/src/rlx_util.erl
@@ -160,7 +160,8 @@ render(Template, Data) when is_list(Template) ->
     render(rlx_util:to_binary(Template), Data);
 render(Template, Data) when is_binary(Template) ->
     case catch bbmustache:render(Template, Data,
-                                 [{key_type, atom}]) of
+                                 [{key_type, atom},
+                                  {escape_fun, fun(X) -> X end}]) of
         Bin when is_binary(Bin) -> {ok, Bin};
         _ -> {error, render_failed}
     end.


### PR DESCRIPTION
The mustache template engine escapes HTML entities by default. This is quite
annoying since we are not generating HTML pages in a web application. This
problem was already referenced in
https://github.com/erlware/relx/issues/497. Now that bbmustache supports a way
to disable escaping by default, there is no reason not to do it.

Additionally, escaping is already disabled in rebar3 templates (see
fe8626ff7de635cc84da61b8b3deb553fe9572c9), so having both templating systems
behave the same way makes sense.