### PR TITLE
set dist_listen to false for command that grabs the hostname

### DIFF
--- a/priv/templates/extended_bin
+++ b/priv/templates/extended_bin
@@ -256,6 +256,7 @@ relx_get_nodename() {
                       -mode interactive \
                       -boot_var SYSTEM_LIB_DIR "$SYSTEM_LIB_DIR" \
                       -eval '[_,H]=re:split(atom_to_list(node()),"@",[unicode,{return,list}]), io:format("~s~n",[H]), halt()' \
+                      -dist_listen false \
                       ${START_EPMD} \
                       -noshell "${NAME_TYPE}" "$id"
     else
@@ -265,6 +266,7 @@ relx_get_nodename() {
                       -boot_var SYSTEM_LIB_DIR "$SYSTEM_LIB_DIR" \
                       -eval '[_,H]=re:split(atom_to_list(node()),"@",[unicode,{return,list}]), io:format("~s~n",[H]), halt()' \
                       -setcookie "${COOKIE}" \
+                      -dist_listen false \
                       ${START_EPMD} \
                       -noshell "${NAME_TYPE}" "$id"
     fi


### PR DESCRIPTION
Without dist_listen set to false this command will try to bind to
a listen port which will fail if epmd isn't being started. There
is no need to set a port for it to listen on since it is only
there to get the hostname.