### PR TITLE
include vm.args or vm.args.src by default if they exist

### DIFF
--- a/src/rlx_config.erl
+++ b/src/rlx_config.erl
@@ -86,14 +86,26 @@ load({release, {RelName, Vsn}, Applications, Config}, {ok, State0}) ->
     {ok, rlx_state:add_configured_release(State0, Release2)};
 load({vm_args, false}, {ok, State}) ->
     {ok, rlx_state:vm_args(State, false)};
+load({vm_args, undefined}, {ok, State}) ->
+    {ok, rlx_state:vm_args(State, undefined)};
 load({vm_args, VmArgs}, {ok, State}) ->
     {ok, rlx_state:vm_args(State, filename:absname(VmArgs))};
+load({vm_args_src, false}, {ok, State}) ->
+    {ok, rlx_state:vm_args_src(State, false)};
+load({vm_args_src, undefined}, {ok, State}) ->
+    {ok, rlx_state:vm_args_src(State, undefined)};
 load({vm_args_src, VmArgs}, {ok, State}) ->
     {ok, rlx_state:vm_args_src(State, filename:absname(VmArgs))};
 load({sys_config, false}, {ok, State}) ->
     {ok, rlx_state:sys_config(State, false)};
+load({sys_config, undefined}, {ok, State}) ->
+    {ok, rlx_state:sys_config(State, undefined)};
 load({sys_config, SysConfig}, {ok, State}) ->
     {ok, rlx_state:sys_config(State, filename:absname(SysConfig))};
+load({sys_config_src, false}, {ok, State}) ->
+    {ok, rlx_state:sys_config_src(State, false)};
+load({sys_config_src, undefined}, {ok, State}) ->
+    {ok, rlx_state:sys_config_src(State, undefined)};
 load({sys_config_src, SysConfigSrc}, {ok, State}) ->
     {ok, rlx_state:sys_config_src(State, filename:absname(SysConfigSrc))};
 load({root_dir, Root}, {ok, State}) ->

--- a/src/rlx_state.erl
+++ b/src/rlx_state.erl
@@ -107,9 +107,9 @@
                   config_file=[] :: file:filename() | undefined,
                   available_apps=#{} :: #{atom() => rlx_app_info:t()},
                   vm_args :: file:filename() | false | undefined,
-                  vm_args_src :: file:filename() | undefined,
+                  vm_args_src :: file:filename() | false | undefined,
                   sys_config :: file:filename() | false | undefined,
-                  sys_config_src :: file:filename() | undefined,
+                  sys_config_src :: file:filename() | false | undefined,
                   overrides=[] :: [{AppName::atom(), Directory::file:filename()}],
                   exclude_apps=[] :: [AppName::atom()],
                   exclude_modules=[] :: [{App::atom(), [Module::atom()]}],
@@ -229,11 +229,11 @@ vm_args(#state_t{vm_args=VmArgs}) ->
 vm_args(State, VmArgs) ->
     State#state_t{vm_args=VmArgs}.
 
--spec vm_args_src(t()) -> file:filename() | undefined.
+-spec vm_args_src(t()) -> file:filename() | false | undefined.
 vm_args_src(#state_t{vm_args_src=VmArgs}) ->
     VmArgs.
 
--spec vm_args_src(t(), undefined | file:filename()) -> t().
+-spec vm_args_src(t(), undefined | false | file:filename()) -> t().
 vm_args_src(State, VmArgs) ->
     State#state_t{vm_args_src=VmArgs}.
 
@@ -241,15 +241,15 @@ vm_args_src(State, VmArgs) ->
 sys_config(#state_t{sys_config=SysConfig}) ->
     SysConfig.
 
--spec sys_config(t(), false | file:filename()) -> t().
+-spec sys_config(t(), false | undefined | file:filename()) -> t().
 sys_config(State, SysConfig) ->
     State#state_t{sys_config=SysConfig}.
 
--spec sys_config_src(t()) -> file:filename() | undefined.
+-spec sys_config_src(t()) -> file:filename() | false | undefined.
 sys_config_src(#state_t{sys_config_src=SysConfigSrc}) ->
     SysConfigSrc.
 
--spec sys_config_src(t(), file:filename() | undefined) -> t().
+-spec sys_config_src(t(), file:filename() | false | undefined) -> t().
 sys_config_src(State, SysConfigSrc) ->
     State#state_t{sys_config_src=SysConfigSrc}.
 

--- a/test/rlx_release_SUITE.erl
+++ b/test/rlx_release_SUITE.erl
@@ -73,8 +73,6 @@ init_per_testcase(_, Config) ->
     [{out_dir, OutputDir} | Config].
 
 end_per_testcase(_, _) ->
-    %% prevents failures in tests when xref fails to stop
-    application:stop(xref),
     ok.
 
 make_release(Config) ->

--- a/test/rlx_release_SUITE.erl
+++ b/test/rlx_release_SUITE.erl
@@ -181,6 +181,7 @@ make_extend_release(Config) ->
                     goal_app_2]},
                   {release, {foo_test, "0.0.1", {extend, foo}},
                    [goal_app_2]},
+                  {check_for_undefined_functions, false},
                   {lib_dirs, [filename:join(LibDir1, "*")]}],
 
     {ok, State} = relx:build_release(foo_test, [{root_dir, LibDir1}, {lib_dirs, [LibDir1]},


### PR DESCRIPTION
Still some ugly code in assemble but at least there are tests now so I feel safer when I go back and refactor -- as well as adding additional tests to cover all the possible combinations of the configs.