### PR TITLE
add exports of RELEASE_NAME, RELEASE_VERSION and RELEASE_PROG to script

### DIFF
--- a/priv/templates/bin
+++ b/priv/templates/bin
@@ -8,8 +8,14 @@ if [ -z "$SCRIPT" ]; then
 fi;
 SCRIPT_DIR="$(cd "$(dirname "$SCRIPT")" && pwd -P)"
 RELEASE_ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd -P)"
-REL_NAME="{{ rel_name }}"
+export REL_NAME="{{ rel_name }}"
 REL_VSN="{{ rel_vsn }}"
+
+# export these to match mix release environment variables
+export RELEASE_NAME="{{ rel_name }}"
+export RELEASE_VSN="{{ rel_vsn }}"
+export RELEASE_PROG="${SCRIPT}"
+
 ERTS_VSN="{{ erts_vsn }}"
 REL_DIR="$RELEASE_ROOT_DIR/releases/$REL_VSN"
 ERL_OPTS="{{ erl_opts }}"

--- a/priv/templates/bin_windows
+++ b/priv/templates/bin_windows
@@ -7,6 +7,11 @@ set rel_vsn={{ rel_vsn }}
 set erts_vsn={{ erts_vsn }}
 set erl_opts={{ erl_opts }}
 
+:: export these to match mix release environment variables
+set RELEASE_NAME={{ rel_name }}
+set RELEASE_VSN={{ rel_vsn }}
+set RELEASE_PROG=%~nx0
+
 :: Set the root release directory based on the location of this batch file
 set script_dir=%~dp0
 for %%A in ("%script_dir%\..") do (

--- a/priv/templates/bin_windows_ps
+++ b/priv/templates/bin_windows_ps
@@ -10,6 +10,11 @@ $rel_vsn = '{{ rel_vsn }}'
 $erts_vsn = '{{ erts_vsn }}'
 $erl_opts = '{{ erl_opts }}'
 
+# export these to match mix release environment variables
+$RELEASE_NAME = '{{ rel_name }}'
+$RELEASE_VERSION = '{{ rel_vsn }}'
+$RELEASE_PROG = $MyInvocation.MyCommand.Name
+
 # Ensure we have PSScriptRoot
 if (!(Test-Path variable:global:PSScriptRoot)) {
     # Support for powershell 2.0

--- a/priv/templates/extended_bin
+++ b/priv/templates/extended_bin
@@ -34,6 +34,12 @@ RELEASE_ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd -P)"
 # Make the value available to variable substitution calls below
 export REL_NAME="{{ rel_name }}"
 REL_VSN="{{ rel_vsn }}"
+
+# export these to match mix release environment variables
+export RELEASE_NAME="{{ rel_name }}"
+export RELEASE_VSN="{{ rel_vsn }}"
+export RELEASE_PROG="${SCRIPT}"
+
 ERTS_VSN="{{ erts_vsn }}"
 REL_DIR="$RELEASE_ROOT_DIR/releases/$REL_VSN"
 RUNNER_LOG_DIR="${RUNNER_LOG_DIR:-$RELEASE_ROOT_DIR/log}"

--- a/priv/templates/extended_bin_windows
+++ b/priv/templates/extended_bin_windows
@@ -21,6 +21,11 @@ set rel_vsn={{ rel_vsn }}
 set erts_vsn={{ erts_vsn }}
 set erl_opts={{ erl_opts }}
 
+:: export these to match mix release environment variables
+set RELEASE_NAME={{ rel_name }}
+set RELEASE_VSN={{ rel_vsn }}
+set RELEASE_PROG=%~nx0
+
 :: Make sure `findstr` is accessible
 set PATH=%PATH%;%SystemRoot%\System32
 

--- a/priv/templates/extended_bin_windows_ps
+++ b/priv/templates/extended_bin_windows_ps
@@ -27,6 +27,11 @@ $rel_vsn = '{{ rel_vsn }}'
 $erts_vsn = '{{ erts_vsn }}'
 $erl_opts = '{{ erl_opts }}'
 
+# export these to match mix release environment variables
+$RELEASE_NAME = '{{ rel_name }}'
+$RELEASE_VERSION = '{{ rel_vsn }}'
+$RELEASE_PROG = $MyInvocation.MyCommand.Name
+
 # Ensure we have PSScriptRoot
 if (!(Test-Path variable:global:PSScriptRoot)) {
     # Support powershell 2.0


### PR DESCRIPTION
These environment variables are for libraries like Opentelemetry
to get information about the running release (and the script used
to run the release in the case of RELEASE_PROG), particularly when
release_handler isn't available.