### PR TITLE
Concurrent Builds - xref interactions refinement

### DIFF
--- a/src/rlx_assemble.erl
+++ b/src/rlx_assemble.erl
@@ -762,7 +762,7 @@ add_project_apps_to_xref(Rf, [AppSpec | Rest], State) ->
                     ?log_warn("Error adding application ~s to xref context: ~s",
                               [rlx_app_info:name(App), xref:format_error(Error)])
             end;
-        error ->
+        _ ->
             ok
     end,
     add_project_apps_to_xref(Rf, Rest, State).


### PR DESCRIPTION
As raised in https://github.com/erlware/relx/issues/851 running releases concurrently (discovered by running `rebar3 release --all`) results in crashes within `maybe_check_for_undefined_functions_/2` as it assumes the xref server is not already running.
This pull request has a separate xref server for each release name thereby allowing multiple releases to execute concurrently without crashing.