### PR TITLE
relx_resolve:to_app raise error with .app file pathname

### DIFF
--- a/src/rlx_resolve.erl
+++ b/src/rlx_resolve.erl
@@ -194,7 +194,10 @@ check_app(Name, Vsn, App) ->
         andalso rlx_app_info:vsn(App) =:= Vsn.
 
 to_app(Name, Vsn, AppFilePath) ->
-    {ok, [{application, _AppName, AppData}]} = file:consult(AppFilePath),
+    AppData = case file:consult(AppFilePath) of
+                  {ok, [{application, _Name, Data}]} -> Data;
+                  Other -> erlang:error(?RLX_ERROR({bad_app_file, AppFilePath, Other}))
+              end,
     Applications = proplists:get_value(applications, AppData, []),
     IncludedApplications = proplists:get_value(included_applications, AppData, []),
 


### PR DESCRIPTION
for some uknown reasons some app file(s) may not exist
the error `{badmatch,{error,enoent}}` isn't quite helpful

e.g. https://github.com/emqx/emqx/issues/4524