### PR TITLE
allow adding a prefix to semver again

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -3,7 +3,10 @@
 {deps, [{bbmustache, "~>1.10"}]}.
 
 %% Compiler Options ============================================================
-{erl_opts, [debug_info, warnings_as_errors, inline]}.
+{erl_opts, [
+            debug_info, warnings_as_errors, inline,
+            {platform_define, "^2", unicode_str}
+           ]}.
 
 %% Profiles ====================================================================
 

--- a/src/rlx_string.erl
+++ b/src/rlx_string.erl
@@ -7,7 +7,7 @@
 -ifdef(unicode_str).
 concat(Str1, Str2) -> unicode:characters_to_list([Str1,Str2]).
 lexemes(Str, Separators) -> string:lexemes(Str, Separators).
-trim(Str, Direction, Cluster=[_]) -> string:trim(Str, Direction, Cluster).
+trim(Str, Direction, Cluster=[_|_]) -> string:trim(Str, Direction, Cluster).
 -else.
 concat(Str1, Str2) -> string:concat(Str1, Str2).
 lexemes(Str, Separators) -> string:tokens(Str, Separators).


### PR DESCRIPTION
This got lost at some point, but I have been relying on it (we've just upgraded from rebar 3.13).

I tried to test it, but it doesn't actually work completely because when this is compiled as a rebar3 library application, `-D unicode_str` (which should happen because of this: https://github.com/erlang/rebar3/blob/master/rebar.config#L38) doesn't seem to be defined, causing a fallback to the OTP-19 behavior.  This should work, but I haven't been able to confirm that it actually does.  Maybe with the actual release pathway instead of bootstrap?