### PR TITLE
use random:uniform instead of os:pid when constructing node name in nodetool

### DIFF
--- a/priv/templates/nodetool
+++ b/priv/templates/nodetool
@@ -153,11 +153,12 @@ nodename(Name) ->
     end.
 
 append_node_suffix(Name, Suffix) ->
+    random:seed(os:timestamp()),
     case re:split(Name, "@", [{return, list}, unicode]) of
         [Node, Host] ->
-            list_to_atom(lists:concat([Node, Suffix, os:getpid(), "@", Host]));
+            list_to_atom(lists:concat([Node, Suffix, random:uniform(1000), "@", Host]));
         [Node] ->
-            list_to_atom(lists:concat([Node, Suffix, os:getpid()]))
+            list_to_atom(lists:concat([Node, Suffix, random:uniform(1000)]))
     end.
 
 %% convert string to erlang term


### PR DESCRIPTION
Borrowing from https://github.com/basho/node_package/blob/4.0/priv/base/nodetool#L195, this is to help reduce the risk of hitting the atom table limit, as was reported by one of our customers who was calling riak-admin continuously and frequently enough to trigger the atom table overflow.