### PR TITLE
avoid quoting $@ in bin script's exec

### DIFF
--- a/priv/templates/bin
+++ b/priv/templates/bin
@@ -79,4 +79,6 @@ set -- "$ERL_OPTS"
 set -- "$@" -boot_var ERTS_LIB_DIR "$ERTS_LIB_DIR" -boot "$REL_DIR/$BOOTFILE" "$ARGS"
 
 # Boot the release
-exec "$BINDIR/erlexec" "$@"
+#   don't quote $@ to keep the arguments split
+# shellcheck disable=SC2068
+exec "$BINDIR/erlexec" $@


### PR DESCRIPTION
The issue appears to be that when we use `exec <cmd> "$@"`, the whole
argument chain is passed as a single argument to `<cmd>` rather than
keeping them split up as many arguments.

This causes issues booting a release with long argument chains to
instead boot with a single one, which in turn causes all sorts of
failures.

shellcheck is actually misleading here, so we remove the quoting and
mute it.

Reported in https://github.com/erlang/rebar3/issues/2548