### PR TITLE
Tweak CI versions (add 24)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        otp_version: [19, 20, 21, 22, 23]
+        otp_version: [19, 20, 21, 22, 23, 24]
         os: [ubuntu-latest]
 
     container:

--- a/.github/workflows/wintest.yml
+++ b/.github/workflows/wintest.yml
@@ -3,11 +3,9 @@ name: Windows Test
 on:
   pull_request:
     branches:
-      - '4.0.0'
       - 'master'
   push:
     branches:
-      - '4.0.0'
       - 'master'
 
 jobs:
@@ -18,14 +16,13 @@ jobs:
     strategy:
       matrix:
         # Cannot test OTP 21 due to https://bugs.erlang.org/browse/ERL-644 (see also https://github.com/elixir-lang/elixir/issues/7774)
-        otp_version: [19, 20, 22, 23]
+        otp_version: [22, 23, 24]
         os: [windows-latest]
 
     steps:
     - uses: actions/checkout@v2
-    - uses: gleam-lang/setup-erlang@v1.1.0
+    - uses: erlef/setup-beam@v1
       with:
         otp-version: ${{ matrix.otp_version }}
-      id: install_erlang
     - name: Run test
-      run: shelltests/wintest.ps1 "${{ steps.install_erlang.outputs.erlpath }}"
+      run: shelltests/wintest.ps1

--- a/priv/templates/extended_bin_windows
+++ b/priv/templates/extended_bin_windows
@@ -47,7 +47,6 @@ set vm_args=%rel_dir%\vm.args
 set progname=erl.exe
 set clean_boot_script=%rel_dir%\start_clean
 set erlsrv="%bindir%\erlsrv.exe"
-set epmd="%bindir%\epmd.exe"
 set escript="%bindir%\escript.exe"
 set werl="%bindir%\werl.exe"
 set erl="%bindir%\erl.exe"
@@ -292,7 +291,6 @@ goto :eof
 :: Uninstall the Windows service
 :uninstall
 %erlsrv% remove %service_name%
-%epmd% -kill
 goto :eof
 
 :: Start the Windows service

--- a/priv/templates/extended_bin_windows_ps
+++ b/priv/templates/extended_bin_windows_ps
@@ -65,7 +65,6 @@ $bindir = "$erts_dir\bin"
 $werl = "$bindir\werl.exe"
 $erl = "$bindir\erl.exe"
 $erlsrv = "$bindir\erlsrv.exe"
-$epmd = "$bindir\epmd.exe"
 $escript = "$bindir\escript.exe"
 
 # Added in OTP-23
@@ -305,7 +304,6 @@ function Uninstall() {
     }
     # Uninstall the Windows service
     & $erlsrv remove $service_name
-    & $epmd -kill
 }
 
 # Start the Windows service

--- a/shelltests/wintest.ps1
+++ b/shelltests/wintest.ps1
@@ -1,22 +1,9 @@
 #! /usr/bin/pwsh
-param (
-    [Parameter(Mandatory=$true, Position=0)]
-    [string]$erlpath
-)
-
 # Test build, install, start, ping, stop, uninstall of powershell_release
 $release = "powershell_release"
 
 # Terminate on error
 $ErrorActionPreference = "Stop"
-
-# Get ERTS version
-# $erts_vsn = & "$erlpath\bin\erl.exe" -boot no_dot_erlang -noshell -eval 'io:format(\"~s\", [erlang:system_info(version)]), halt().'
-
-# Add erlpath to PATH
-"*** Add to PATH $erlpath\bin"
-$env:PATH = "$env:PATH;$erlpath\bin"
-""
 
 # CD to script location (shelltests)
 Set-Location $PSScriptRoot
@@ -46,7 +33,7 @@ Pop-Location
 
 # Function to run rebar3
 function Rebar() {
-    & $erlpath\bin\escript.exe "$rebar3_dir\rebar3" @args
+    & escript.exe "$rebar3_dir\rebar3" @args
     if ($LASTEXITCODE -ne 0) {
         Write-Error "rebar3 ${args} exited with status $LASTEXITCODE"
     }


### PR DESCRIPTION
I'm not sure if there's something to be done with `shelltest.yml`, since it mentions `23.1`.

**Edit**:

* [X] ~wait until there's a `gleam-lang/setup-erlang` version that also pulls in Erlang 24.0 for Windows~ (**edit**: `setup-beam` now pulls for Windows, but only 21+)