### PR TITLE
optionally allow static node name suffixes

### DIFF
--- a/priv/templates/extended_bin
+++ b/priv/templates/extended_bin
@@ -365,7 +365,14 @@ erl_eval() {
 
 # Generate a random id
 relx_gen_id() {
-    dd count=1 bs=4 if=/dev/urandom 2> /dev/null | od -x  | head -n1 | awk '{print $2$3}'
+    # To prevent exhastion of atoms on target node, optionally avoid
+    # generation of random node prefixes, if it is guaranteed calls
+    # are entirely sequential.
+    if [ x != x$NODETOOL_NODE_PREFIX ]; then
+        echo $NODETOOL_NODE_PREFIX
+    else
+        dd count=1 bs=4 if=/dev/urandom 2> /dev/null | od -x  | head -n1 | awk '{print $2$3}'
+    fi
 }
 
 # Control a node with nodetool if erl_call isn't from OTP-23+


### PR DESCRIPTION
Instances of nodetool generate random node name suffxes to facilitate running multiple simultaneous calls in parallel.  However, each time nodetool connects to the target node, a new atom is created on the latter.  If this happens frequently and/or long enough, it will eventually crash the node as it hits the atom table limit.  As a workaround, if the caller can guarantee calls are serialized and isolated in time, defining an env variable $NODETOOL_NODE_PREFIX will create identical atoms for node name prefix, thus avoiding generation of new atoms.

The proposed change is complimentary to https://github.com/erlware/relx/pull/868, aiming to address the issue, reported by one of our customers, in which a riak node hit the atom table limit (yes, all of 1M+ entries) and crashed. A postmortem showed the table filled with `maint1a2b3c4d-riak@127.0.0.1`, accumulated over a period of time resulting from calls to `riak admin status` every 5 min.

Note that I did not attempt to do any changes that may need to be done, to the same effect, in extended_bin_windows, as it's not straightforward for me which they would be (my knowledge of scripting in Windows is some 30 year old).