### PR TITLE
Stores the warnings from xref as part of the rlx_state instead of printing them

### DIFF
--- a/src/rlx_state.erl
+++ b/src/rlx_state.erl
@@ -93,7 +93,9 @@
          exref/2,
          check_for_undefined_functions/1,
          check_for_undefined_functions/2,
-         is_relx_sasl/1]).
+         is_relx_sasl/1,
+         xref_warnings/1,
+         add_xref_warnings/2]).
 
 -type mode() :: dev | prod | minimal.
 
@@ -133,6 +135,7 @@
                   extended_start_script_extensions=[] :: list(),
                   generate_start_script=true :: boolean(),
                   include_start_scripts_for=undefined :: [atom()] | undefined,
+                  xref_warnings = [] :: [{mfa(), mfa()}],
 
                   %% `dev_mode' is for backwards compatibility
                   dev_mode=false :: boolean(),
@@ -188,7 +191,7 @@ exclude_apps(State, ExcludeApps) ->
 exclude_modules(#state_t{exclude_modules=Modules}) ->
     Modules.
 
-%% @doc modules to be excluded from the release 
+%% @doc modules to be excluded from the release
 -spec exclude_modules(t(), [{App::atom(), [Module::atom()]}]) -> t().
 exclude_modules(State, SkipModules) ->
     State#state_t{exclude_modules=SkipModules}.
@@ -335,6 +338,15 @@ include_nodetool(#state_t{include_nodetool=IncludeNodetool}) ->
 include_nodetool(S, IncludeNodetool) ->
     S#state_t{include_nodetool=IncludeNodetool}.
 
+
+-spec add_xref_warnings(t(), [{mfa(), mfa()}]) -> t().
+add_xref_warnings(#state_t{xref_warnings = Warnings} = S, XrefWarning) ->
+    S#state_t{xref_warnings = XrefWarning ++ Warnings}.
+
+-spec xref_warnings(t()) -> [{mfa(), mfa()}].
+xref_warnings(#state_t{xref_warnings = Warnings}) ->
+    Warnings.
+
 -spec overlay(t()) -> list() | undefined.
 overlay(#state_t{overlay=Overlay}) ->
     Overlay.
@@ -420,7 +432,7 @@ format(Mod) ->
     format(Mod, 0).
 
 -spec format(t(), non_neg_integer()) -> iolist().
-format(#state_t{output_dir=OutDir, 
+format(#state_t{output_dir=OutDir,
                 lib_dirs=LibDirs},
        Indent) ->
     [rlx_util:indent(Indent),

--- a/test/rlx_tar_SUITE.erl
+++ b/test/rlx_tar_SUITE.erl
@@ -52,7 +52,7 @@ basic_tar(Config) ->
                   {sys_config_src, SysConfigSrc},
                   {vm_args_src, VmArgsSrc}],
 
-    {ok, Release} = relx:build_tar(foo, [{root_dir, LibDir1}, {lib_dirs, [LibDir1]},
+    {ok, Release, _State} = relx:build_tar(foo, [{root_dir, LibDir1}, {lib_dirs, [LibDir1]},
                                          {output_dir, OutputDir} | RelxConfig]),
 
     AppSpecs = rlx_release:app_specs(Release),
@@ -89,7 +89,7 @@ exclude_erts(Config) ->
                     goal_app_2]},
                   {include_erts, false}
                  ],
-    {ok, Release} = relx:build_tar(foo, [{root_dir, LibDir1}, {lib_dirs, [LibDir1]},
+    {ok, Release, _State} = relx:build_tar(foo, [{root_dir, LibDir1}, {lib_dirs, [LibDir1]},
                                          {output_dir, OutputDir} | RelxConfig]),
 
     AppSpecs = rlx_release:app_specs(Release),
@@ -117,7 +117,7 @@ exclude_src(Config) ->
                     goal_app_2]},
                   {include_src, false}],
 
-    {ok, Release} = relx:build_tar(foo, [{root_dir, LibDir1}, {lib_dirs, [LibDir1]},
+    {ok, Release, _State} = relx:build_tar(foo, [{root_dir, LibDir1}, {lib_dirs, [LibDir1]},
                                          {output_dir, OutputDir} | RelxConfig]),
 
     AppSpecs = rlx_release:app_specs(Release),
@@ -144,7 +144,7 @@ include_src(Config) ->
                     goal_app_2]},
                   {include_src, true}],
 
-    {ok, Release} = relx:build_tar(foo, [{root_dir, LibDir1}, {lib_dirs, [LibDir1]},
+    {ok, Release, _State} = relx:build_tar(foo, [{root_dir, LibDir1}, {lib_dirs, [LibDir1]},
                                          {output_dir, OutputDir} | RelxConfig]),
 
     AppSpecs = rlx_release:app_specs(Release),
@@ -233,7 +233,7 @@ overlay_archive(Config) ->
     {ok, FileInfo} = file:read_file_info(TemplateFile),
     ok = file:write_file_info(TemplateFile, FileInfo#file_info{mode=8#00777}),
 
-    {ok, Release} = relx:build_tar(foo, [{root_dir, LibDir1}, {lib_dirs, [LibDir1]},
+    {ok, Release, _State} = relx:build_tar(foo, [{root_dir, LibDir1}, {lib_dirs, [LibDir1]},
                                          {output_dir, OutputDir} | RelxConfig]),
 
     AppSpecs = rlx_release:app_specs(Release),


### PR DESCRIPTION
Before, the warning from xref were printed to the console,
Whis this commit, the warnings are stored in the rlx_state, and the required modifications are carried to make sure the entries methods of the module all return the modified rlx_state.

This transfers the responsability to deal with these warnings to rebar3.

Notably, it allows rebar3 to call code from the rebar_prv_xref plugin to disregard warnings that should be ignored by xref (-ignore_xref tag in the modules or in rebar.config).

Test Plan: rebar3 ct && rebar3 dialyzer
+ on a custom project, with custom rebar3 
rebar3 release
