### PR TITLE
Fix bin script arguments to erlexec

### DIFF
--- a/priv/templates/bin
+++ b/priv/templates/bin
@@ -65,20 +65,31 @@ export BINDIR="$ERTS_DIR/bin"
 export EMU="beam"
 export PROGNAME="erl"
 export LD_LIBRARY_PATH="$ERTS_DIR/lib:$LD_LIBRARY_PATH"
-ERTS_LIB_DIR="$ERTS_DIR/../lib"
+SYSTEM_LIB_DIR="$(dirname "$ERTS_DIR")/lib"
 [ -f "$REL_DIR/$REL_NAME.boot" ] && BOOTFILE="$REL_NAME" || BOOTFILE=start
 cd "$ROOTDIR"
 
+{{! Define alternative field separator using ASCII US (unit separator). US is
+    not expected to appear in any argument. }}
+IFS_NORM="$IFS"
+IFS_ARGS="$(printf '\x1f')"
+
 # Save extra arguments
-ARGS=$*
+{{! Join extra arguments into a US-delimited string. }}
+IFS="$IFS_ARGS"
+ARGS="$*"
+IFS="$IFS_NORM"
 
 # Build arguments for erlexec
-set -- "$ERL_OPTS"
+set --
+[ "$ERL_OPTS" ] && set -- "$@" "$ERL_OPTS"
 [ "$SYS_CONFIG" ] && set -- "$@" -config "$SYS_CONFIG"
 [ "$VM_ARGS" ] && set -- "$@" -args_file "$VM_ARGS"
-set -- "$@" -boot_var ERTS_LIB_DIR "$ERTS_LIB_DIR" -boot "$REL_DIR/$BOOTFILE" "$ARGS"
+set -- "$@" -boot_var SYSTEM_LIB_DIR "$SYSTEM_LIB_DIR" -boot "$REL_DIR/$BOOTFILE"
+{{! Split string with extra arguments back into an argument list. }}
+IFS="$IFS_ARGS"
+# shellcheck disable=SC2086
+set -- "$@" $ARGS
+IFS="$IFS_NORM"
 
-# Boot the release
-#   don't quote $@ to keep the arguments split
-# shellcheck disable=SC2068
-exec "$BINDIR/erlexec" $@
+exec "$BINDIR/erlexec" "$@"


### PR DESCRIPTION
- These changes affect the bin script for releases compiled with `{extended_start_script, false}`.

- Save extra arguments to bin script in a variable delimited with ASCII US (unit separator).
    - This is for compatibility with POSIX sh. (Bash, on the other hand, would allow these arguments to be saved as an array.)
    - Unit separators were chosen for their rarity and not expected to appear in an argument.

- Prevent empty arguments from being passed to `erlexec` command-line and causing a crash
    - Only include `"$ERL_OPTS"` if it is non-empty.
    - If there are no extra arguments, do not include an empty string.
    - Issue: https://github.com/erlang/rebar3/issues/2548

- Restore quotes for `"$@"` to prevent additional word splitting on default value of `IFS`.

- Rename `ERTS_LIB_DIR` to `SYSTEM_LIB_DIR`.
    - This prevents releases compiled with `{erts, false}, {system_libs, false}` from crashing with `init terminating in do_boot (cannot expand $SYSTEM_LIB_DIR in bootfile)`
    - Related: https://github.com/erlang/rebar3/issues/1674
    - Fixes https://github.com/erlware/relx/commit/efc5604b2ccf557a54e1a1a35c6ee53c5578258e

Motivation: https://github.com/erlang/rebar3/issues/2548#issuecomment-886003434

## Testing

- See example project and before/after comparisons at https://github.com/mxxk/relx-pr-879-example