### PR TITLE
State extended with a filter method to filter xref_warnings

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -40,7 +40,7 @@
                 {rlx_state, format, 1},
                 {rlx_state, format, 2},
                 {rlx_state, dev_mode, 1},
-		{rlx_state, filter_xref_warning, 2},
+           		{rlx_state, filter_xref_warning, 2},
 
                 %% used in tests
                 {rlx_app_info, new, 5},

--- a/rebar.config
+++ b/rebar.config
@@ -40,6 +40,7 @@
                 {rlx_state, format, 1},
                 {rlx_state, format, 2},
                 {rlx_state, dev_mode, 1},
+		{rlx_state, filter_xref_warning, 2},
 
                 %% used in tests
                 {rlx_app_info, new, 5},

--- a/src/rlx_assemble.erl
+++ b/src/rlx_assemble.erl
@@ -734,7 +734,9 @@ maybe_check_for_undefined_functions_(State, Release) ->
             %% release
             case xref:analyze(Rf, undefined_function_calls) of
                 {ok, Warnings} ->
-                    format_xref_warning(Warnings);
+                    FilterMethod = rlx_state:filter_xref_warning(State),
+                    FilteredWarnings = FilterMethod(Warnings),
+                    format_xref_warning(FilteredWarnings);
                 {error, _} = Error ->
                     ?log_warn(
                         "Error running xref analyze: ~s", 

--- a/src/rlx_state.erl
+++ b/src/rlx_state.erl
@@ -93,7 +93,9 @@
          exref/2,
          check_for_undefined_functions/1,
          check_for_undefined_functions/2,
-         is_relx_sasl/1]).
+         is_relx_sasl/1,
+         filter_xref_warning/1,
+         filter_xref_warning/2]).
 
 -type mode() :: dev | prod | minimal.
 
@@ -133,6 +135,7 @@
                   extended_start_script_extensions=[] :: list(),
                   generate_start_script=true :: boolean(),
                   include_start_scripts_for=undefined :: [atom()] | undefined,
+                  filter_xref_warning = fun(Warnings) -> Warnings end :: fun((list({mfa(), mfa()})) -> list({mfa(), mfa()})),
 
                   %% `dev_mode' is for backwards compatibility
                   dev_mode=false :: boolean(),
@@ -260,6 +263,13 @@ root_dir(#state_t{root_dir=RootDir}) ->
 -spec root_dir(t(), file:filename()) -> t().
 root_dir(State, RootDir) ->
     State#state_t{root_dir=filename:absname(RootDir)}.
+
+-spec filter_xref_warning(t()) -> fun((list({mfa(), mfa()})) -> list({mfa(), mfa()})).
+filter_xref_warning(#state_t{filter_xref_warning=Filter}) -> Filter.
+
+-spec filter_xref_warning(t(), fun((list({mfa(), mfa()})) -> list({mfa(), mfa()}))) -> t().
+filter_xref_warning(State, Filter) -> State#state_t{filter_xref_warning=Filter}.
+
 
 -spec add_configured_release(t(), rlx_release:t()) -> t().
 add_configured_release(M=#state_t{configured_releases=Releases}, Release) ->


### PR DESCRIPTION
   We extend RELX state with a method that is used to filter XREF warnings.
    
   This method is by default just the identity function.
    
   This is designed in such a way that rebar3 can pass it the method it currently relies on to deal with the ignore_xref attributes in the future, while offering no regression with current rebar3 versions.