### PR TITLE
add support for optional deps in otp24

### DIFF
--- a/src/rlx_app_info.erl
+++ b/src/rlx_app_info.erl
@@ -36,13 +36,14 @@
 %%%
 -module(rlx_app_info).
 
--export([new/5,
-         new/6,
+-export([new/6,
+         new/7,
          name/1,
          vsn/1,
          dir/1,
          applications/1,
          included_applications/1,
+         optional_applications/1,
          link/1,
          link/2,
          format_error/1,
@@ -71,17 +72,18 @@
 -export_type([t/0,
               app_type/0]).
 
--spec new(atom(), string(), file:name(), [atom()], [atom()]) -> t().
-new(Name, Vsn, Dir, Applications, IncludedApplications) ->
-    new(Name, Vsn, Dir, Applications, IncludedApplications, dep).
+-spec new(atom(), string(), file:name(), [atom()], [atom()], [atom()]) -> t().
+new(Name, Vsn, Dir, Applications, IncludedApplications, OptionalApplications) ->
+    new(Name, Vsn, Dir, Applications, IncludedApplications, OptionalApplications, dep).
 
--spec new(atom(), string(), file:name(), [atom()], [atom()], app_type()) -> t().
-new(Name, Vsn, Dir, Applications, IncludedApplications, AppType) ->
+-spec new(atom(), string(), file:name(), [atom()], [atom()], [atom()], app_type()) -> t().
+new(Name, Vsn, Dir, Applications, IncludedApplications, OptionalApplications, AppType) ->
     #{name => Name,
       vsn => Vsn,
 
       applications => Applications,
       included_applications => IncludedApplications,
+      optional_applications => OptionalApplications,
 
       dir => Dir,
       link => false,
@@ -106,6 +108,10 @@ applications(#{applications := Deps}) ->
 
 -spec included_applications(t()) -> [atom()].
 included_applications(#{included_applications := Deps}) ->
+    Deps.
+
+-spec optional_applications(t()) -> [atom()].
+optional_applications(#{included_applications := Deps}) ->
     Deps.
 
 -spec link(t()) -> boolean().

--- a/test/rlx_test_utils.erl
+++ b/test/rlx_test_utils.erl
@@ -10,20 +10,20 @@ create_app(Dir, Name, Vsn, Deps, LibDeps) ->
     write_src_file(AppDir, Name),
     write_priv_file(AppDir),
     compile_src_files(AppDir),
-    rlx_app_info:new(erlang:list_to_atom(Name), Vsn, AppDir, Deps, []).
+    rlx_app_info:new(erlang:list_to_atom(Name), Vsn, AppDir, Deps, [], []).
 
 create_full_app(Dir, Name, Vsn, Deps, LibDeps) ->
     AppDir = filename:join([Dir, Name ++ "-" ++ Vsn]),
     write_full_app_files(AppDir, Name, Vsn, Deps, LibDeps),
     compile_src_files(AppDir),
     rlx_app_info:new(erlang:list_to_atom(Name), Vsn, AppDir,
-                     Deps, []).
+                     Deps, [], []).
 
 create_empty_app(Dir, Name, Vsn, Deps, LibDeps) ->
     AppDir = filename:join([Dir, Name ++ "-" ++ Vsn]),
     write_app_file(AppDir, Name, Vsn, [], Deps, LibDeps),
     rlx_app_info:new(erlang:list_to_atom(Name), Vsn, AppDir,
-                     Deps, []).
+                     Deps, [], []).
 
 app_modules(Name) ->
     [list_to_atom(M ++ Name) ||


### PR DESCRIPTION
rebar3 currently throws an error when building releases with optional applications, which were added in OTP 24. see:
https://github.com/erlang/rebar3/issues/2473 for more context.  it turns out that relx assumes that all deps it knows about are required, so this PR threads the optional application information through rebar3 and into relx, then does the right thing with it.