### PR TITLE
extended_bin: Ignore ERL_DIST_PORT on OTP 22

### DIFF
--- a/priv/templates/extended_bin
+++ b/priv/templates/extended_bin
@@ -683,7 +683,7 @@ if [ "$ERL_DIST_PORT" ]; then
         else
             EXTRA_DIST_ARGS="-erl_epmd_port ${ERL_DIST_PORT}"
         fi
-    else
+    elif [  "11.0" = "$(printf "%s\n11.0" "${ERTS_VSN}" | sort -V | head -n1)" ] ; then
         EXTRA_DIST_ARGS="-kernel inet_dist_listen_min ${ERL_DIST_PORT} -kernel inet_dist_listen_max ${ERL_DIST_PORT}"
     fi
 fi


### PR DESCRIPTION
Don't set the kernel options `inet_dist_listen_{min,max}` on Erlang/OTP releases prior to 23.0.  On those versions, the `remote_console` VM and nodetool would attempt to listen on the same port as the main VM (because [`-dist_listen false`][1] is not yet supported), and therefore fail to start up.

[1]: https://www.erlang.org/doc/man/kernel_app.html#dist_listen