### PR TITLE
More helpful error if file:consult fails with .app (#892)

### DIFF
--- a/src/rlx_assemble.erl
+++ b/src/rlx_assemble.erl
@@ -132,7 +132,13 @@ rewrite_app_file(State, App, TargetDir) ->
 
     %% TODO: should really read this in when creating rlx_app:t() and keep it
     AppFile = filename:join([TargetDir, "ebin", [Name, ".app"]]),
-    {ok, [{application, AppName, AppData0}]} = file:consult(AppFile),
+    ?log_debug("Rewriting .app file: ~s", [AppFile]),
+    [{application, AppName, AppData0}] = case file:consult(AppFile) of
+        {ok, AppTerms} ->
+            AppTerms;
+        {error, ConsultError} ->
+            erlang:error(?RLX_ERROR({consult_app_file, AppFile, ConsultError}))
+    end,
 
     %% maybe replace excluded apps
     AppData1 = maybe_exclude_apps(Applications, IncludedApplications,
@@ -1085,6 +1091,14 @@ format_error({strip_release, Reason}) ->
                   [beam_lib:format_error(Reason)]);
 format_error({rewrite_app_file, AppFile, Error}) ->
     io_lib:format("Unable to rewrite .app file ~s due to ~p",
+                  [AppFile, Error]);
+format_error({consult_app_file, AppFile, enoent}) ->
+    io_lib:format("Unable to read .app file ~s (file not found).~n"
+                  "If the app and hex package are named differently, you will need to specify the~n"
+                  "dependency in rebar.config with {AppName, {pkg, PackageName}}",
+                  [AppFile]);
+format_error({consult_app_file, AppFile, Error}) ->
+    io_lib:format("Unable to read .app file ~s due to ~p",
                   [AppFile, Error]);
 format_error({create_RELEASES, Reason}) ->
     io_lib:format("Unable to create RELEASES file needed by release_handler: ~p", [Reason]).


### PR DESCRIPTION
Improve error messages around file:consult errors related to .app files either being missing, or a misconfiguration.

Response to https://github.com/erlware/relx/issues/892