### PR TITLE
More helpful error if file:consult fails with .app

### DIFF
--- a/src/rlx_assemble.erl
+++ b/src/rlx_assemble.erl
@@ -1093,7 +1093,7 @@ format_error({rewrite_app_file, AppFile, Error}) ->
     io_lib:format("Unable to rewrite .app file ~s due to ~p",
                   [AppFile, Error]);
 format_error({consult_app_file, AppFile, enoent}) ->
-    io_lib:format("Unable to consult .app file ~s (file not found).~n",
+    io_lib:format("Unable to consult .app file ~ts (file not found).",
                   [AppFile]);
 format_error({consult_app_file, AppFile, Error}) ->
     io_lib:format("Unable to consult .app file ~s due to ~p",

--- a/src/rlx_assemble.erl
+++ b/src/rlx_assemble.erl
@@ -1096,7 +1096,7 @@ format_error({consult_app_file, AppFile, enoent}) ->
     io_lib:format("Unable to consult .app file ~ts (file not found).",
                   [AppFile]);
 format_error({consult_app_file, AppFile, Error}) ->
-    io_lib:format("Unable to consult .app file ~s due to ~p",
-                  [AppFile, Error]);
+    io_lib:format("Unable to consult .app file ~ts due to ~ts",
+                  [AppFile, file:format_error(Error)]);
 format_error({create_RELEASES, Reason}) ->
     io_lib:format("Unable to create RELEASES file needed by release_handler: ~p", [Reason]).

--- a/src/rlx_assemble.erl
+++ b/src/rlx_assemble.erl
@@ -132,7 +132,13 @@ rewrite_app_file(State, App, TargetDir) ->
 
     %% TODO: should really read this in when creating rlx_app:t() and keep it
     AppFile = filename:join([TargetDir, "ebin", [Name, ".app"]]),
-    {ok, [{application, AppName, AppData0}]} = file:consult(AppFile),
+    ?log_debug("Rewriting .app file: ~s", [AppFile]),
+    [{application, AppName, AppData0}] = case file:consult(AppFile) of
+        {ok, AppTerms} ->
+            AppTerms;
+        {error, ConsultError} ->
+            erlang:error(?RLX_ERROR({consult_app_file, AppFile, ConsultError}))
+    end,
 
     %% maybe replace excluded apps
     AppData1 = maybe_exclude_apps(Applications, IncludedApplications,
@@ -1085,6 +1091,12 @@ format_error({strip_release, Reason}) ->
                   [beam_lib:format_error(Reason)]);
 format_error({rewrite_app_file, AppFile, Error}) ->
     io_lib:format("Unable to rewrite .app file ~s due to ~p",
+                  [AppFile, Error]);
+format_error({consult_app_file, AppFile, enoent}) ->
+    io_lib:format("Unable to consult .app file ~s (file not found).~n",
+                  [AppFile]);
+format_error({consult_app_file, AppFile, Error}) ->
+    io_lib:format("Unable to consult .app file ~s due to ~p",
                   [AppFile, Error]);
 format_error({create_RELEASES, Reason}) ->
     io_lib:format("Unable to create RELEASES file needed by release_handler: ~p", [Reason]).


### PR DESCRIPTION
Per discussion, I've removed the reference to the rebar dependency and it will just print an error message related to the missing .app file.  I've also changed the phrasing from "unable to read" to "unable to consult." (given that it's a failure to use `file:consult` on the file in question).

I'm hoping this is better!

In the meantime, I may dig into the rebar3 code to try and catch this error sooner than later (not sure if I'll have time this weekend).

Response to https://github.com/erlware/relx/issues/892

See previous discussion here: https://github.com/erlware/relx/pull/893