### PR TITLE
keep order of deps in order given in release config

### DIFF
--- a/test/rlx_release_SUITE.erl
+++ b/test/rlx_release_SUITE.erl
@@ -43,7 +43,8 @@ groups() ->
        make_exclude_modules_release, make_release_with_sys_config_vm_args_src,
        make_exclude_app_release, make_overridden_release, make_goalless_release,
        make_one_app_top_level_release, make_release_twice, make_erts_release,
-       make_erts_config_release, make_included_nodetool_release, make_release_goal_order]},
+       make_erts_config_release, make_included_nodetool_release, make_release_goal_reorder,
+       make_release_keep_goal_order]},
      {dev_mode, [shuffle], [make_dev_mode_template_release,
                             make_dev_mode_release,
                             make_release_twice_dev_mode]},
@@ -100,20 +101,48 @@ make_release(Config) ->
     ?assert(lists:member({goal_app_2, "0.0.1"}, AppSpecs)),
     ?assert(lists:member({lib_dep_1, "0.0.1", load}, AppSpecs)).
 
-make_release_goal_order(Config) ->
-  LibDir = ?config(lib_dir, Config),
-  OutputDir = ?config(out_dir, Config),
+make_release_goal_reorder(Config) ->
+    LibDir = ?config(lib_dir, Config),
+    OutputDir = ?config(out_dir, Config),
 
-  RelxConfig = [{release, {ordered_foo, "0.0.1"},
-                 [goal_app_2, goal_app_1]},
+    RelxConfig = [{release, {reordered_foo, "0.0.1"},
+                   [goal_app_2, goal_app_1]},
                   {check_for_undefined_functions, false}],
 
-  {ok, State} = relx:build_release(ordered_foo, [{root_dir, LibDir}, {lib_dirs, [LibDir]},
-                                                 {output_dir, OutputDir} | RelxConfig]),
+    {ok, State} = relx:build_release(reordered_foo, [{root_dir, LibDir}, {lib_dirs, [LibDir]},
+                                                     {output_dir, OutputDir} | RelxConfig]),
 
-  [{{ordered_foo, "0.0.1"}, Release}] = maps:to_list(rlx_state:realized_releases(State)),
-  AppSpecs = rlx_release:app_specs(Release),
-  ?assertMatch([{goal_app_2, "0.0.1"}, {goal_app_1, "0.0.1"} | _], AppSpecs).
+    [{{reordered_foo, "0.0.1"}, Release}] = maps:to_list(rlx_state:realized_releases(State)),
+    AppSpecs = rlx_release:app_specs(Release),
+
+    %% goal_app_2 depends on goal_app_1, so the two are reordered when building the .rel file
+    ?assertMatch([{kernel,_},
+                  {stdlib,_},
+                  {lib_dep_1,"0.0.1",load},
+                  {non_goal_1,"0.0.1"},
+                  {goal_app_1,"0.0.1"},
+                  {non_goal_2,"0.0.1"},
+                  {goal_app_2,"0.0.1"}], AppSpecs).
+
+make_release_keep_goal_order(Config) ->
+    LibDir = ?config(lib_dir, Config),
+    OutputDir = ?config(out_dir, Config),
+
+    RelxConfig = [{release, {ordered_foo, "0.0.1"},
+                   [non_goal_2, lib_dep_1]},
+                  {check_for_undefined_functions, false}],
+
+    {ok, State} = relx:build_release(ordered_foo, [{root_dir, LibDir}, {lib_dirs, [LibDir]},
+                                                   {output_dir, OutputDir} | RelxConfig]),
+
+    [{{ordered_foo, "0.0.1"}, Release}] = maps:to_list(rlx_state:realized_releases(State)),
+    AppSpecs = rlx_release:app_specs(Release),
+
+    %% goal_app_2 depends on goal_app_1, so the two are reordered when building the .rel file
+    ?assertMatch([{kernel,_},
+                  {stdlib,_},
+                  {non_goal_2,"0.0.1"},
+                  {lib_dep_1,"0.0.1"}], AppSpecs).
 
 make_config_release(Config) ->
     DataDir = ?config(priv_dir, Config),


### PR DESCRIPTION
Two commits and two changes. Main one is ensuring the order of the apps given by the user in the relx config is the same as the one we output to `.rel` file, unless the app is a dependency of an app given earlier in the relx list.

So for relx list of `[A, B, C]` where `A` depends on `B` and `C` depends on `D` we would generate a `.rel` file of `[B, A, D, C]`.