### PR TITLE
add support for optional_applications in otp24

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -45,6 +45,7 @@
                 %% used in tests
                 {rlx_app_info, new, 5},
                 {rlx_app_info, new, 6},
+                {rlx_app_info, new, 7},
                 {rlx_file_utils, type, 1},
                 {rlx_file_utils, write, 2},
                 {rlx_release, applications, 1},

--- a/src/rlx_app_info.erl
+++ b/src/rlx_app_info.erl
@@ -38,11 +38,13 @@
 
 -export([new/5,
          new/6,
+         new/7,
          name/1,
          vsn/1,
          dir/1,
          applications/1,
          included_applications/1,
+         optional_applications/1,
          link/1,
          link/2,
          format_error/1,
@@ -57,6 +59,7 @@
 
                applications          := [atom()],
                included_applications := [atom()],
+               optional_applications := [atom()],
 
                dir                   := file:name() | undefined,
                link                  := boolean() | undefined,
@@ -73,15 +76,23 @@
 
 -spec new(atom(), string(), file:name(), [atom()], [atom()]) -> t().
 new(Name, Vsn, Dir, Applications, IncludedApplications) ->
-    new(Name, Vsn, Dir, Applications, IncludedApplications, dep).
+    new(Name, Vsn, Dir, Applications, IncludedApplications, [], dep).
 
--spec new(atom(), string(), file:name(), [atom()], [atom()], app_type()) -> t().
-new(Name, Vsn, Dir, Applications, IncludedApplications, AppType) ->
+-spec new(atom(), string(), file:name(), [atom()], [atom()], [atom()] | atom()) -> t().
+new(Name, Vsn, Dir, Applications, IncludedApplications, OptionalApplications)
+  when is_list(OptionalApplications) ->
+    new(Name, Vsn, Dir, Applications, IncludedApplications, OptionalApplications, dep);
+new(Name, Vsn, Dir, Applications, IncludedApplications, AppType) when is_atom(AppType) ->
+    new(Name, Vsn, Dir, Applications, IncludedApplications, [], AppType).
+
+-spec new(atom(), string(), file:name(), [atom()], [atom()], [atom()], app_type()) -> t().
+new(Name, Vsn, Dir, Applications, IncludedApplications, OptionalApplications, AppType) ->
     #{name => Name,
       vsn => Vsn,
 
       applications => Applications,
       included_applications => IncludedApplications,
+      optional_applications => OptionalApplications,
 
       dir => Dir,
       link => false,
@@ -106,6 +117,10 @@ applications(#{applications := Deps}) ->
 
 -spec included_applications(t()) -> [atom()].
 included_applications(#{included_applications := Deps}) ->
+    Deps.
+
+-spec optional_applications(t()) -> [atom()].
+optional_applications(#{included_applications := Deps}) ->
     Deps.
 
 -spec link(t()) -> boolean().


### PR DESCRIPTION
Optional applications may or may not also be in the applications
list. They are also only optional for the app that lists them
as optional, unlike an excluded application which is global. So
what is optional for app A may be required by app B and thus
cause a failure if it is not found when building the release.