### PR TITLE
print a warning about use of ERL_DIST_PORT on erts prior to 11.1

### DIFF
--- a/priv/templates/extended_bin
+++ b/priv/templates/extended_bin
@@ -709,6 +709,13 @@ if [ "$ERL_DIST_PORT" ]; then
             EXTRA_DIST_ARGS="-erl_epmd_port ${ERL_DIST_PORT}"
         fi
     else
+        ERL_DIST_PORT_WARNING="ERL_DIST_PORT is set and used to set the port, but doing so on ERTS version ${ERTS_VSN} means remsh/rpc will not work for this release"
+        if ! command -v logger > /dev/null 2>&1
+        then
+            echo "WARNING: ${ERL_DIST_PORT_WARNING}"
+        else
+            logger -p warning -t "${REL_NAME}[$$]" "${ERL_DIST_PORT_WARNING}"
+        fi
         EXTRA_DIST_ARGS="-kernel inet_dist_listen_min ${ERL_DIST_PORT} -kernel inet_dist_listen_max ${ERL_DIST_PORT}"
     fi
 fi


### PR DESCRIPTION
@weiss how about this as a replacement for https://github.com/erlware/relx/pull/890 ?