### PR TITLE
Use `erlexec` directly in relx helper functions

### DIFF
--- a/priv/templates/extended_bin
+++ b/priv/templates/extended_bin
@@ -259,24 +259,24 @@ relx_get_nodename() {
     id="longname$(relx_gen_id)-${NAME}"
     if [ -z "$COOKIE" ]; then
         # shellcheck disable=SC2086
-        "$BINDIR/erl" -boot "$REL_DIR"/start_clean \
-                      -mode interactive \
-                      -boot_var SYSTEM_LIB_DIR "$SYSTEM_LIB_DIR" \
-                      -eval '[_,H]=re:split(atom_to_list(node()),"@",[unicode,{return,list}]), io:format("~s~n",[H]), halt()' \
-                      -dist_listen false \
-                      ${START_EPMD} \
-                      -noshell "${NAME_TYPE}" "$id"
+        "$BINDIR/erlexec" -boot "$REL_DIR"/start_clean \
+                          -mode interactive \
+                          -boot_var SYSTEM_LIB_DIR "$SYSTEM_LIB_DIR" \
+                          -eval '[_,H]=re:split(atom_to_list(node()),"@",[unicode,{return,list}]), io:format("~s~n",[H]), halt()' \
+                          -dist_listen false \
+                          ${START_EPMD} \
+                          -noshell "${NAME_TYPE}" "$id"
     else
         # running with setcookie prevents a ~/.erlang.cookie from being created
         # shellcheck disable=SC2086
-        "$BINDIR/erl" -boot "$REL_DIR"/start_clean \
-                      -mode interactive \
-                      -boot_var SYSTEM_LIB_DIR "$SYSTEM_LIB_DIR" \
-                      -eval '[_,H]=re:split(atom_to_list(node()),"@",[unicode,{return,list}]), io:format("~s~n",[H]), halt()' \
-                      -setcookie "${COOKIE}" \
-                      -dist_listen false \
-                      ${START_EPMD} \
-                      -noshell "${NAME_TYPE}" "$id"
+        "$BINDIR/erlexec" -boot "$REL_DIR"/start_clean \
+                          -mode interactive \
+                          -boot_var SYSTEM_LIB_DIR "$SYSTEM_LIB_DIR" \
+                          -eval '[_,H]=re:split(atom_to_list(node()),"@",[unicode,{return,list}]), io:format("~s~n",[H]), halt()' \
+                          -setcookie "${COOKIE}" \
+                          -dist_listen false \
+                          ${START_EPMD} \
+                          -noshell "${NAME_TYPE}" "$id"
     fi
 }
 

--- a/priv/templates/extended_bin
+++ b/priv/templates/extended_bin
@@ -305,7 +305,7 @@ relx_rem_sh() {
     # -dist_listen is new in OTP-23. It keeps the remote node from binding to a listen port
     # and implies the option -hidden
     # shellcheck disable=SC2086
-    exec "$BINDIR/erl" ${remote_nodename} -remsh "$NAME" -boot "$REL_DIR"/start_clean -mode interactive \
+    exec "$BINDIR/erlexec" ${remote_nodename} -remsh "$NAME" -boot "$REL_DIR"/start_clean -mode interactive \
          -boot_var SYSTEM_LIB_DIR "$SYSTEM_LIB_DIR" \
          -setcookie "$COOKIE" -hidden -kernel net_ticktime "$TICKTIME" \
          -dist_listen false \


### PR DESCRIPTION
...Instead of `$BINDIR/erl`.

Latter might resolve to the system-wide `erl` script, notably when a release has been made with `{include_erts, false}` and `{system_libs, true}` (which is usual).

In such a case even the smallest discrepancy in versions between an Erlang/OTP used to assemble a release (e.g. 24.1.7) and an Erlang/OTP running it later (e.g. 24.2.0) will draw such release impossible to start. This happens because relx helper functions employ `start_clean` bootfile from a release, and this bootfile attempts to start core application (kernel / stdlib) versions as seen at the build time, which will not be present system-wide at the run time.