### PR TITLE
keep attributes when stripping beams

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        otp_version: [19, 20, 21, 22, 23, 24]
+        otp_version: [22, 23, 24]
         os: [ubuntu-latest]
 
     container:

--- a/src/rlx_assemble.erl
+++ b/src/rlx_assemble.erl
@@ -39,7 +39,7 @@ do(Release, State) ->
                         end
                     end
                 ],
-            try beam_lib:strip_release(OutputDir) of
+            try beam_lib:strip_release(OutputDir,["Attr"]) of
                 {ok, _} ->
                     {ok, State1};
                 {error, _, Reason} ->


### PR DESCRIPTION
release_handler:install_release/1 depends on the 'vsn' attribute in the beam
files of the to-be-installed release.

Without this, a release created with {debug_info, strip} (which is the default in
rebar3 'prod' and 'minimal' modes) cannot be installed by the release_handler.