### PR TITLE
Fix include_erts=false failure with OTP-25.0-rc2

### DIFF
--- a/priv/templates/bin
+++ b/priv/templates/bin
@@ -8,6 +8,7 @@ if [ -z "$SCRIPT" ]; then
 fi;
 SCRIPT_DIR="$(cd "$(dirname "$SCRIPT")" && pwd -P)"
 RELEASE_ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd -P)"
+ROOTDIR="$RELEASE_ROOT_DIR"
 export REL_NAME="{{ rel_name }}"
 REL_VSN="{{ rel_vsn }}"
 
@@ -60,7 +61,6 @@ find_vm_args() {
 find_erts_dir
 find_sys_config
 find_vm_args
-export ROOTDIR="$RELEASE_ROOT_DIR"
 export BINDIR="$ERTS_DIR/bin"
 export EMU="beam"
 export PROGNAME="erl"
@@ -85,7 +85,7 @@ set --
 [ "$ERL_OPTS" ] && set -- "$@" "$ERL_OPTS"
 [ "$SYS_CONFIG" ] && set -- "$@" -config "$SYS_CONFIG"
 [ "$VM_ARGS" ] && set -- "$@" -args_file "$VM_ARGS"
-set -- "$@" -boot_var SYSTEM_LIB_DIR "$SYSTEM_LIB_DIR" -boot "$REL_DIR/$BOOTFILE"
+set -- "$@" -boot_var SYSTEM_LIB_DIR "$SYSTEM_LIB_DIR" -boot_var RELEASE_DIR "$RELEASE_ROOT_DIR" -boot "$REL_DIR/$BOOTFILE"
 {{! Split string with extra arguments back into an argument list. }}
 IFS="$IFS_ARGS"
 # shellcheck disable=SC2086

--- a/priv/templates/extended_bin
+++ b/priv/templates/extended_bin
@@ -31,6 +31,7 @@ esac
 [ -z "$SCRIPT" ] && SCRIPT=$0
 SCRIPT_DIR="$(cd "$(dirname "$SCRIPT")" && pwd -P)"
 RELEASE_ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd -P)"
+ROOTDIR="$RELEASE_ROOT_DIR"
 # Make the value available to variable substitution calls below
 export REL_NAME="{{ rel_name }}"
 REL_VSN="{{ rel_vsn }}"
@@ -262,6 +263,7 @@ relx_get_nodename() {
         "$BINDIR/erl" -boot "$REL_DIR"/start_clean \
                       -mode interactive \
                       -boot_var SYSTEM_LIB_DIR "$SYSTEM_LIB_DIR" \
+                      -boot_var RELEASE_DIR "$RELEASE_ROOT_DIR" \
                       -eval '[_,H]=re:split(atom_to_list(node()),"@",[unicode,{return,list}]), io:format("~s~n",[H]), halt()' \
                       -dist_listen false \
                       ${START_EPMD} \
@@ -272,6 +274,7 @@ relx_get_nodename() {
         "$BINDIR/erl" -boot "$REL_DIR"/start_clean \
                       -mode interactive \
                       -boot_var SYSTEM_LIB_DIR "$SYSTEM_LIB_DIR" \
+                      -boot_var RELEASE_DIR "$RELEASE_ROOT_DIR" \
                       -eval '[_,H]=re:split(atom_to_list(node()),"@",[unicode,{return,list}]), io:format("~s~n",[H]), halt()' \
                       -setcookie "${COOKIE}" \
                       -dist_listen false \
@@ -307,6 +310,7 @@ relx_rem_sh() {
     # shellcheck disable=SC2086
     exec "$BINDIR/erl" ${remote_nodename} -remsh "$NAME" -boot "$REL_DIR"/start_clean -mode interactive \
          -boot_var SYSTEM_LIB_DIR "$SYSTEM_LIB_DIR" \
+         -boot_var RELEASE_DIR "$RELEASE_ROOT_DIR" \
          -setcookie "$COOKIE" -hidden -kernel net_ticktime "$TICKTIME" \
          -dist_listen false \
          $DIST_ARGS \
@@ -597,7 +601,6 @@ process_internal_args "$@"
 
 find_erts_dir
 find_erl_call
-export ROOTDIR="$RELEASE_ROOT_DIR"
 export BINDIR="$ERTS_DIR/bin"
 export EMU="beam"
 export PROGNAME="erl"
@@ -979,6 +982,7 @@ case "$1" in
         echo "Exec: $BINDIR/erlexec" $FOREGROUNDOPTIONS \
             -boot "$BOOTFILE" -mode "$CODE_LOADING_MODE" \
             -boot_var SYSTEM_LIB_DIR "$SYSTEM_LIB_DIR" \
+            -boot_var RELEASE_DIR "$RELEASE_ROOT_DIR" \
             -config "$RELX_CONFIG_PATH" \
             -args_file "$VMARGS_PATH" \
             $EXTRA_DIST_ARGS -- "$@"
@@ -1000,6 +1004,7 @@ case "$1" in
         exec "$BINDIR/erlexec" $FOREGROUNDOPTIONS \
             -boot "$BOOTFILE" -mode "$CODE_LOADING_MODE" \
             -boot_var SYSTEM_LIB_DIR "$SYSTEM_LIB_DIR" \
+            -boot_var RELEASE_DIR "$RELEASE_ROOT_DIR" \
             -config "$RELX_CONFIG_PATH" \
             -args_file "$VMARGS_PATH" \
             $EXTRA_DIST_ARGS -- "$@"

--- a/src/rlx_assemble.erl
+++ b/src/rlx_assemble.erl
@@ -863,24 +863,11 @@ make_boot_script_variables(Release, State) ->
     % A boot variable is needed when {system_libs, false} and the application
     % directories are split between the release/lib directory and the erlang
     % install directory on the target host.
-    % The built-in $ROOT variable points to the erts directory on Windows
-    % (dictated by erl.ini [erlang] Rootdir=) and so a boot variable is made
-    % pointing to the release directory
-    % On non-Windows, $ROOT is set by the ROOTDIR environment variable as the
-    % release directory, so a boot variable is made pointing to the erts
-    % directory.
     % NOTE the boot variable can point to either the release/erts root directory
     % or the release/erts lib directory, as long as the usage here matches the
     % usage used in the start up scripts
-    case {os:type(), rlx_state:system_libs(State)} of
-        {{win32, _}, false} ->
-            [{"RELEASE_DIR", filename:join(rlx_state:base_output_dir(State),
-                                           rlx_release:name(Release))}];
-        {{win32, _}, true} ->
-            [];
-        _ ->
-            [{"SYSTEM_LIB_DIR", code:lib_dir()}]
-    end.
+    [{"RELEASE_DIR", filename:join(rlx_state:base_output_dir(State), rlx_release:name(Release))},
+     {"SYSTEM_LIB_DIR", code:lib_dir()}].
 
 create_no_dot_erlang(RelDir, OutputDir, Options, _State) ->
     create_other_boot_file(RelDir, [no_dot_erlang | Options], "no_dot_erlang"),


### PR DESCRIPTION
At OTP 25.0-rc2, the release with setting `{include_erts, false}` results in error.

```
(default) % _build/dev/rel/devmode/bin/devmode console
Exec: /home/shino/local/otp/25.0-rc2/erts-13.0/bin/erlexec -boot /home/shino/g/devmode/_build/dev/rel/devmode/releases/0.0.0/start -mode interactive -boot_var SYSTEM_LIB_DIR /home/shino/local/otp/25.0-rc2/lib -config /home/shino/g/devmode/_build/dev/rel/devmode/releases/0.0.0/sys.config -args_file /home/shino/g/devmode/_build/dev/rel/devmode/releases/0.0.0/vm.args -- console
Root: /home/shino/g/devmode/_build/dev/rel/devmode
/home/shino/g/devmode/_build/dev/rel/devmode
Can not find inet_gethost for erts-13.0/x86_64-pc-linux-gnu

Crash dump is being written to: erl_crash.dump...done
```

cf. Release fails to start when rebar3's include_erts=false is used, 25.0-rc2 · Issue #5826 · erlang/otp
    https://github.com/erlang/otp/issues/5826

The current relx's release sets `ROOTDIR` to `RELEASE_ROOT_DIR` and exports it, and `code:root_dir()` is set to there.
On the other hand, https://github.com/erlang/otp/commit/a32f6d210a58ba1e56f54f07c91106efed2c0777 assumes there exists `ROOTDIR/erts-<VSN>/bin/inet_gethost`, which is spec conformant acording to the discussion at https://github.com/erlang/otp/issues/5826 .

This PR's changes are as follows:
- Don't export `ROOTDIR`
- Use `RELEASE_DIR` boot variable as it is used in windows case

------

Because I don't have windows box, this PR might be incomplete.  Anyway, I hope this can be the base for discussion.

