### PR TITLE
Cosmetic change: Omit .config file extension from -config argument

### DIFF
--- a/priv/templates/bin
+++ b/priv/templates/bin
@@ -83,7 +83,7 @@ IFS="$IFS_NORM"
 # Build arguments for erlexec
 set --
 [ "$ERL_OPTS" ] && set -- "$@" "$ERL_OPTS"
-[ "$SYS_CONFIG" ] && set -- "$@" -config "$SYS_CONFIG"
+[ "$SYS_CONFIG" ] && set -- "$@" -config "${SYS_CONFIG%.config}"
 [ "$VM_ARGS" ] && set -- "$@" -args_file "$VM_ARGS"
 set -- "$@" -boot_var SYSTEM_LIB_DIR "$SYSTEM_LIB_DIR" -boot "$REL_DIR/$BOOTFILE"
 {{! Split string with extra arguments back into an argument list. }}

--- a/priv/templates/bin_windows
+++ b/priv/templates/bin_windows
@@ -41,7 +41,7 @@ echo Rootdir=%converted_rootdir% >> "%erl_ini%"
 
 :: Start the release in an `erl` shell
 set boot=-boot "%boot_script%" -boot_var RELEASE_DIR "%release_root_dir%"
-"%erl%" %erl_opts% %sys_config% %boot% %*
+"%erl%" %erl_opts% %sys_config:.config=% %boot% %*
 
 goto :eof
 

--- a/priv/templates/extended_bin
+++ b/priv/templates/extended_bin
@@ -979,7 +979,7 @@ case "$1" in
         echo "Exec: $BINDIR/erlexec" $FOREGROUNDOPTIONS \
             -boot "$BOOTFILE" -mode "$CODE_LOADING_MODE" \
             -boot_var SYSTEM_LIB_DIR "$SYSTEM_LIB_DIR" \
-            -config "$RELX_CONFIG_PATH" \
+            -config ${RELX_CONFIG_PATH%.config} \
             -args_file "$VMARGS_PATH" \
             $EXTRA_DIST_ARGS -- "$@"
         echo "Root: $ROOTDIR"
@@ -1000,7 +1000,7 @@ case "$1" in
         exec "$BINDIR/erlexec" $FOREGROUNDOPTIONS \
             -boot "$BOOTFILE" -mode "$CODE_LOADING_MODE" \
             -boot_var SYSTEM_LIB_DIR "$SYSTEM_LIB_DIR" \
-            -config "$RELX_CONFIG_PATH" \
+            -config ${RELX_CONFIG_PATH%.config} \
             -args_file "$VMARGS_PATH" \
             $EXTRA_DIST_ARGS -- "$@"
         # exec will replace the current image and nothing else gets

--- a/priv/templates/extended_bin_windows
+++ b/priv/templates/extended_bin_windows
@@ -317,7 +317,7 @@ goto :eof
 :: Start a console
 :console
 set boot=-boot "%boot_script%" -boot_var RELEASE_DIR "%release_root_dir%"
-start "%rel_name% console" %werl% %boot% %sys_config%  ^
+start "%rel_name% console" %werl% %boot% %sys_config:.config=%  ^
        -args_file "%vm_args%"
 goto :eof
 

--- a/priv/templates/psutil
+++ b/priv/templates/psutil
@@ -90,7 +90,7 @@ function Find-FormatConfig()
         }
     }
 
-    return $out
+    return $out -replace '\.config$', ''
 }
 
 function Format-OSVars()


### PR DESCRIPTION
Specify `-config sys` rather than `-config sys.config`. This is what the [erl(1) manual][1] says, it's what other release generators do, and it saves a few characters on the process command line :smile:

However, as both `sys` and `sys.config` will work, this fixes a non-issue, so feel free to just close the PR if you don't like the change.

[1]: https://erlang.org/doc/man/erl.html#flags