### PR TITLE
Make rlx_util:parse_vsn parse integer versions

### DIFF
--- a/src/rlx_util.erl
+++ b/src/rlx_util.erl
@@ -72,7 +72,12 @@ parse_vsn(Vsn) ->
         {match, [Major, Minor, Patch, PreRelease, Build]} ->
             {{list_to_integer(Major), list_to_integer(Minor), list_to_integer(Patch)}, {PreRelease, Build}};
         _ ->
-            0
+            try list_to_integer(Vsn) of
+                Major ->
+                    {{Major, 0, 0}, {"", ""}}
+            catch _:_ ->
+                {{0, 0, 0}, {"", ""}}
+            end
     end.
 
 %% less than or equal to comparison for versions parsed with `parse_vsn'


### PR DESCRIPTION
This allows using integer release versions "1", "2" and so on instead of semver, like was possible in Relx 3. In current main branch this only seems to be an issue when creating relups without providing the previous version, in that case the crash happens at https://github.com/erlware/relx/blob/main/src/rlx_relup.erl#L95

I have also changed the returned value `0` because it resulted in unhelpful crashes down the line because the code didn't expect an integer but a tuple.

Tested against Erlang.mk tests.