### PR TITLE
Fix include_erts,true Windows releases

### DIFF
--- a/src/rlx_assemble.erl
+++ b/src/rlx_assemble.erl
@@ -663,18 +663,17 @@ include_erts(State, Release, OutputDir, RelDir) ->
                     ok = rlx_file_utils:copy(ErtsBinDir, LocalErtsBin,
                                              [recursive, {file_info, [mode, time]}]),
 
-                    case OsFamily of
+                    Result = case OsFamily of
                         unix ->
                             DynErl = filename:join([LocalErtsBin, "dyn_erl"]),
-                            Erl = filename:join([LocalErtsBin, "erl"]);
+                            Erl = filename:join([LocalErtsBin, "erl"]),
+                            ok = rlx_file_utils:ensure_writable(Erl),
+                            rlx_file_utils:copy(DynErl, Erl);
                         win32 ->
-                            DynErl = filename:join([LocalErtsBin, "dyn_erl.ini"]),
-                            Erl = filename:join([LocalErtsBin, "erl.ini"])
+                            ok
                     end,
 
-                    ok = rlx_file_utils:ensure_writable(Erl),
-
-                    case rlx_file_utils:copy(DynErl, Erl) of
+                    case Result of
                         ok ->
                             %% drop yielding_c_fun binary if it exists
                             %% it is large (1.1MB) and only used at compile time


### PR DESCRIPTION
The dyn_erl program does not exist on Windows.

It seems to be unix-specific: https://github.com/erlang/otp/blob/master/erts/etc/unix/dyn_erl.c 