### PR TITLE
Force use of nodetool if proto_dist set

### DIFF
--- a/priv/templates/extended_bin
+++ b/priv/templates/extended_bin
@@ -726,6 +726,11 @@ if [ "$ERL_DIST_PORT" ]; then
     fi
 fi
 
+# Force use of nodetool if proto_dist set as erl_call doesn't support proto_dist
+if [ "$PROTO_DIST" ]; then
+    ERL_RPC=relx_nodetool
+fi
+
 # Extract the target cookie
 # Do this before relx_get_nodename so we can use it and not create a ~/.erlang.cookie
 if [ -n "$RELX_COOKIE" ]; then


### PR DESCRIPTION
When using a custom proto_dist (in our case a custom TLS wrapper) for distribution erl_call doesn't work as it doesn't support proto_dist, and so the extended_bin script doesn't work correctly.

Forcing use of nodetool instead of erl_call in this situation fixes the issue.

If necessary we could also check for specific values of proto_dist to avoid forcing use of nodetool when not strictly required (e.g. still use erl_call if proto_dist is inet_tcp)