### PR TITLE
Also set -dist_listen false for relx_nodetool calls

### DIFF
--- a/priv/templates/extended_bin
+++ b/priv/templates/extended_bin
@@ -388,14 +388,14 @@ relx_nodetool() {
     nodetool_id="maint$(relx_gen_id)-${NAME}"
 
     if [ -z "${START_EPMD}" ]; then
-        ERL_FLAGS="${ERL_FLAGS} ${DIST_ARGS} ${EXTRA_DIST_ARGS} ${NAME_TYPE} $nodetool_id -setcookie ${COOKIE}" \
+        ERL_FLAGS="${ERL_FLAGS} ${DIST_ARGS} ${EXTRA_DIST_ARGS} ${NAME_TYPE} $nodetool_id -setcookie ${COOKIE} -dist_listen false" \
                  "$ERTS_DIR/bin/escript" \
                  "$ROOTDIR/bin/nodetool" \
                  "$NAME_TYPE" "$NAME" \
                  "$command" "$@"
     else
         # shellcheck disable=SC2086
-        ERL_FLAGS="${ERL_FLAGS} ${DIST_ARGS} ${EXTRA_DIST_ARGS} ${NAME_TYPE} $nodetool_id -setcookie ${COOKIE}" \
+        ERL_FLAGS="${ERL_FLAGS} ${DIST_ARGS} ${EXTRA_DIST_ARGS} ${NAME_TYPE} $nodetool_id -setcookie ${COOKIE} -dist_listen false" \
                  "$ERTS_DIR/bin/escript" \
                  "$ROOTDIR/bin/nodetool" \
                  $START_EPMD "$NAME_TYPE" "$NAME" "$command" "$@"


### PR DESCRIPTION
When ERL_DIST_PORT is set nodetool will fail if the port is in use by the target process, in particular ping will fail, so any commands using ping_or_exit with also fail. Setting -dist_listen false is consistent with relx_get_nodename and relx_rem_sh

(Currently attempting to run without epmd on OTP 23.2 based on https://blog.erlware.org/epmdlessless/)