### PR TITLE
Only overwrite erl with dyn_erl if dyn_erl exists

### DIFF
--- a/src/rlx_assemble.erl
+++ b/src/rlx_assemble.erl
@@ -667,8 +667,13 @@ include_erts(State, Release, OutputDir, RelDir) ->
                         unix ->
                             DynErl = filename:join([LocalErtsBin, "dyn_erl"]),
                             Erl = filename:join([LocalErtsBin, "erl"]),
-                            ok = rlx_file_utils:ensure_writable(Erl),
-                            rlx_file_utils:copy(DynErl, Erl);
+                            case filelib:is_regular(DynErl) of
+                                true ->
+                                    ok = rlx_file_utils:ensure_writable(Erl),
+                                    rlx_file_utils:copy(DynErl, Erl);
+                                false ->
+                                    ok
+                            end;
                         win32 ->
                             ok
                     end,


### PR DESCRIPTION
Some Erlang builds might not have the `dyn_erl` executable, so we can't assume it exists. Only overwrite it if it actually exists.

I have only manually verified that this works with our GRiSP plug-in (which releases from a custom Erlang build without `dyn_erl`). Couldn't figure out a simple way to test it. Let me know if you have any hints.