### PR TITLE
Eliminate use of experimental function code:lib_dir/2

### DIFF
--- a/src/rlx_assemble.erl
+++ b/src/rlx_assemble.erl
@@ -741,7 +741,7 @@ maybe_check_for_undefined_functions_(State, Release) ->
             %% without adding the erts application there will be warnings about 
             %% missing functions from the preloaded modules even though they 
             %% are in the runtime.
-            ErtsApp = code:lib_dir(erts, ebin),
+            ErtsApp = filename:join(code:lib_dir(erts), "ebin"),
 
             %% xref library path is what is searched for functions used by the 
             %% project apps. 


### PR DESCRIPTION
The `code:lib_dir/2` function was introduced to support looking into archives. Both archives and the `code:lib_dir/2` are marked as experimental.

In the upcoming Erlang/OTP 27 release, `code:lib_dir/2` will be deprecated. In some future release, the archive functionality will be changed (`escript:extract/2` will continue to work, reading archive members using `erl_prim_loader` will not).