### PR TITLE
Fix type coercion with API usage

### DIFF
--- a/src/rlx_assemble.erl
+++ b/src/rlx_assemble.erl
@@ -777,7 +777,7 @@ add_project_apps_to_xref(Rf, [AppSpec | Rest], State) ->
         {ok, App=#{app_type := project}} ->
             case xref:add_application(
                    Rf,
-                   binary_to_list(rlx_app_info:dir(App)),
+                   unicode:characters_to_list(rlx_app_info:dir(App)),
                    [{name, rlx_app_info:name(App)}, {warnings, false}])
             of
                 {ok, _} ->


### PR DESCRIPTION
While running the rebar3 suite on the newest relx release, a run failed because when called with list directories the conversion failed. Instead we use a unicode-safe approach that better supports the calls we need.