### PR TITLE
Force -mode(interpret) in templated escripts

### DIFF
--- a/priv/templates/install_upgrade_escript
+++ b/priv/templates/install_upgrade_escript
@@ -2,6 +2,7 @@
 %%! -noinput
 %% -*- mode: erlang;erlang-indent-level: 4;indent-tabs-mode: nil -*-
 %% ex: ft=erlang ts=4 sw=4 et
+-mode(interpret).
 
 -define(TIMEOUT, 300000).
 -define(INFO(Fmt,Args), io:format(Fmt,Args)).

--- a/priv/templates/nodetool
+++ b/priv/templates/nodetool
@@ -10,6 +10,7 @@
 %% relx when OTP-23 becomes the earliest support version of OTP.
 %%
 %% -------------------------------------------------------------------
+-mode(interpret).
 
 main(Args) ->
     %% Extract the args


### PR DESCRIPTION
Starting with OTP-27, the escript files are compiled by default instead of running in interpreted mode. Unfortunately for Relx, this causes issues for releases when the application that has been shipped does not bundle the compiler application, and errors come out of it.

For full compatibility and better usage for releases, force files to be interpreted at all times, removing a hidden dependency on the compiler being present.

Fixes https://github.com/erlware/relx/issues/940