### PR TITLE
Fix copy/paste error

### DIFF
--- a/src/rlx_app_info.erl
+++ b/src/rlx_app_info.erl
@@ -120,7 +120,7 @@ included_applications(#{included_applications := Deps}) ->
     Deps.
 
 -spec optional_applications(t()) -> [atom()].
-optional_applications(#{included_applications := Deps}) ->
+optional_applications(#{optional_applications := Deps}) ->
     Deps.
 
 -spec link(t()) -> boolean().


### PR DESCRIPTION
Getter `optional_applications` returned wrong field. Fixes #934