### PR TITLE
extended_bin: Avoid using logger

### DIFF
--- a/priv/templates/extended_bin
+++ b/priv/templates/extended_bin
@@ -996,7 +996,6 @@ case "$1" in
         echo "Root: $ROOTDIR"
 
         # Log the startup
-        echo "$RELEASE_ROOT_DIR"
         if ! command -v logger > /dev/null 2>&1
         then
             echo "${REL_NAME}[$$] Starting up"


### PR DESCRIPTION
The user running the release may not have the privileges required to using `logger(1)`. In that case, `logger(1)` returns non-zero, so the extended start script would [fail][1] (due to [`set -e`][2]).

Modern systems (e.g., systemd-based or container solutions) typically expect services to write log messages to the standard output, and the extended start script does this in other places already. Therefore, just don't bother with `logger(1)` anymore.

[1]: https://github.com/processone/eturnal/issues/84#issuecomment-2672086905
[2]: https://github.com/erlware/relx/blob/v4.9.0/priv/templates/extended_bin#L3