### PR TITLE
extended_bin: Omit superfluous log message

### DIFF
--- a/priv/templates/extended_bin
+++ b/priv/templates/extended_bin
@@ -996,7 +996,6 @@ case "$1" in
         echo "Root: $ROOTDIR"
 
         # Log the startup
-        echo "$RELEASE_ROOT_DIR"
         if ! command -v logger > /dev/null 2>&1
         then
             echo "${REL_NAME}[$$] Starting up"


### PR DESCRIPTION
Currently, lines such as the following are printed during startup:

```
Root: /opt/release
/opt/release
```

The first one prints `$ROOTDIR`, the second one `$RELEASE_ROOT_DIR`. Unless I'm overlooking something, those will [never differ][1]? Therefore, I'd suggest omitting the second line.

[1]: https://github.com/erlware/relx/blob/v4.9.0/priv/templates/extended_bin#L600