### PR TITLE
extended_bin: Avoid using logger

### DIFF
--- a/priv/templates/extended_bin
+++ b/priv/templates/extended_bin
@@ -716,12 +716,7 @@ if [ "$ERL_DIST_PORT" ]; then
         fi
     else
         ERL_DIST_PORT_WARNING="ERL_DIST_PORT is set and used to set the port, but doing so on ERTS version ${ERTS_VSN} means remsh/rpc will not work for this release"
-        if ! command -v logger > /dev/null 2>&1
-        then
-            echo "WARNING: ${ERL_DIST_PORT_WARNING}"
-        else
-            logger -p warning -t "${REL_NAME}[$$]" "${ERL_DIST_PORT_WARNING}"
-        fi
+        echo "WARNING: ${ERL_DIST_PORT_WARNING}"
         EXTRA_DIST_ARGS="-kernel inet_dist_listen_min ${ERL_DIST_PORT} -kernel inet_dist_listen_max ${ERL_DIST_PORT}"
     fi
 fi
@@ -996,12 +991,7 @@ case "$1" in
         echo "Root: $ROOTDIR"
 
         # Log the startup
-        if ! command -v logger > /dev/null 2>&1
-        then
-            echo "${REL_NAME}[$$] Starting up"
-        else
-            logger -t "${REL_NAME}[$$]" "Starting up"
-        fi
+        echo "${REL_NAME}[$$] Starting up"
 
         relx_run_hooks "$PRE_START_HOOKS"
         # Start the VM


### PR DESCRIPTION
The user running the release may not have the privileges required to using `logger(1)`. In that case, `logger(1)` returns non-zero, so the extended start script would [fail][1] (due to [`set -e`][2]).

Modern systems (e.g., systemd-based or container solutions) typically expect services to write log messages to the standard output, and the extended start script does this in other places already. Therefore, just don't bother with `logger(1)` anymore.

[1]: https://github.com/processone/eturnal/issues/84#issuecomment-2672086905
[2]: https://github.com/erlware/relx/blob/v4.9.0/priv/templates/extended_bin#L3