### PR TITLE
extended_bin_windows: Use werl.exe as symlink for OTP >= 26

### DIFF
--- a/priv/templates/extended_bin_windows
+++ b/priv/templates/extended_bin_windows
@@ -55,6 +55,18 @@ set "extensions0={{ extensions }}"
 set "extensions1=%extensions0:|= %"
 set "extensions=%extensions1: undefined=%"
 
+:: Fetch OTP version using erl.exe
+for /f "delims=" %%a in ('"%erl%" -eval "io:format(\"~s\", ^
+  [erlang:system_info(otp_release)]), halt()." -noshell 2^>nul') ^
+do set otp_version=%%a
+
+:: Since OTP 26, werl.exe is a symlink to erl.exe - use same executable
+if defined otp_version (
+  if %otp_version% geq "26" (
+    set werl=%erl%
+  )
+)
+
 :: Extract node type and name from vm.args
 for /f "usebackq tokens=1-2" %%I in (`findstr /b "\-name \-sname" "%vm_args%"`) do (
   set node_type=%%I

--- a/priv/templates/extended_bin_windows
+++ b/priv/templates/extended_bin_windows
@@ -56,9 +56,9 @@ set "extensions1=%extensions0:|= %"
 set "extensions=%extensions1: undefined=%"
 
 :: Fetch OTP version using erl.exe
-for /f "delims=" %%a in ('"%erl%" -eval "io:format(\"~s\", ^
-  [erlang:system_info(otp_release)]), halt()." -noshell 2^>nul') ^
-do set otp_version=%%a
+for /f "delims=" %%a in ('"%erl%" -eval "io:format(\"~s\", [erlang:system_info(otp_release)]), halt()." -noshell 2^>nul') do (
+  set otp_version=%%a
+)
 
 :: Since OTP 26, werl.exe is a symlink to erl.exe - use same executable
 if defined otp_version (

--- a/priv/templates/extended_bin_windows
+++ b/priv/templates/extended_bin_windows
@@ -60,9 +60,6 @@ for /f "delims=" %%a in ('call "%erl%" -boot no_dot_erlang -boot_var RELEASE_DIR
   set "otp_version=%%a"
 )
 
-echo Captured OTP Version: %otp_version%
-echo Should link werl.exe: if "%otp_version%" geq "26"
-
 :: Since OTP 26, werl.exe is a symlink to erl.exe - use same executable
 if defined otp_version (
   if %otp_version% geq "26" (

--- a/priv/templates/extended_bin_windows
+++ b/priv/templates/extended_bin_windows
@@ -56,9 +56,12 @@ set "extensions1=%extensions0:|= %"
 set "extensions=%extensions1: undefined=%"
 
 :: Fetch OTP version using erl.exe
-for /f "delims=" %%a in ('"%erl%" -eval "io:format(\"~s\", [erlang:system_info(otp_release)]), halt()." -noshell 2^>nul') do (
-  set otp_version=%%a
+for /f "delims=" %%a in ('call "%erl%" -boot no_dot_erlang -boot_var RELEASE_DIR "%release_root_dir%" -noshell -eval "io:format(\"~s\", [erlang:system_info(otp_release)])." -s init stop') do (
+  set "otp_version=%%a"
 )
+
+echo Captured OTP Version: %otp_version%
+echo Should link werl.exe: if "%otp_version%" geq "26"
 
 :: Since OTP 26, werl.exe is a symlink to erl.exe - use same executable
 if defined otp_version (


### PR DESCRIPTION
As per the OTP-26 release notes:

"The TTY/terminal subsystem has been rewritten. Windows users will notice that erl.exe has the same functionality as a normal Unix shell and that werl.exe is just a symlink to erl.exe. This makes the Windows Erlang terminal experience identical to that of Unix."

Due to this, the werl.exe was missing for OTP >= 26 on Windows releases.

## Solution

- Dynamically set `werl.exe` to use `erl.exe` when OTP ≥ 26 is detected
- Add version check using `erlang:system_info(otp_release)`
- Use quoted string comparison (`geq "26"`) for safe version checks

Suggestions are welcome if there is another better solution to check the OTP version.

## Notes

I put this PR in draft because I want guidance on **how to test** this change. I'll do more local tests to ensure it's working as expected.

I'm not a Windows user, but I need it for a specific project that needs Windows :)

----

[OTP-26 release notes](https://erlangforums.com/t/erlang-otp-26-0-released/2607#new-terminal-5)