### PR TITLE
Use -fetch_stdout with erl_call to support printing of unicode

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,33 +16,33 @@ jobs:
     strategy:
       matrix:
         otp_version: [26, 27, 28]
-        os: [ubuntu-20.04] # latest only runs >= 24.2
+        os: [ubuntu-latest]
 
     container:
       image: erlang:${{ matrix.otp_version }}
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Compile
-      run: rebar3 compile
-    - name: CT tests
-      run: rebar3 ct
-    - name: Xref
-      run: rebar3 xref
-    - name: Dialyzer
-      run: rebar3 dialyzer
+      - uses: actions/checkout@v2
+      - name: Compile
+        run: rebar3 compile
+      - name: CT tests
+        run: rebar3 ct
+      - name: Xref
+        run: rebar3 xref
+      - name: Dialyzer
+        run: rebar3 dialyzer
 
   macos:
     name: Test on MacOS
     runs-on: macos-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Install Erlang
-      run: brew install erlang
-    - name: Install rebar3
-      run: |
-        wget https://s3.amazonaws.com/rebar3/rebar3
-        chmod +x rebar3
-    - name: CT tests
-      run: ./rebar3 ct
+      - uses: actions/checkout@v2
+      - name: Install Erlang
+        run: brew install erlang
+      - name: Install rebar3
+        run: |
+          wget https://s3.amazonaws.com/rebar3/rebar3
+          chmod +x rebar3
+     - name: CT tests
+        run: ./rebar3 ct

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        otp_version: [23, 24, 26]
+        otp_version: [26, 27, 28]
         os: [ubuntu-20.04] # latest only runs >= 24.2
 
     container:

--- a/priv/templates/extended_bin
+++ b/priv/templates/extended_bin
@@ -227,7 +227,7 @@ find_erl_call() {
         # only OTP-23 and above have erl_call in the erts bin directory
         # and only those versions have the features and bug fixes needed
         # to work properly with this script
-        __erl_call="$ERTS_DIR/bin/erl_call"
+        __erl_call="$ERTS_DIR/bin/erl_call -fetch_stdout"
         if [ -f "$__erl_call" ]; then
             ERL_RPC="$__erl_call";
         else


### PR DESCRIPTION
Per  [this comment](https://erlangforums.com/t/cant-set-unicode-in-release-mode/4779/6) , `erl_call` is not very unicode aware, but it will print what is returned in unicode if the `-fetch_stdout` option is utilized. 

This may be tested by generating a release, starting it up, and then running an eval against it like so : 

```shell
$ _build/default/rel/app/bin/app eval 'io:format("~ts~n",[[257]]).'
ā
ok
```

Inversely,  doing this on main as it is will get you : 

```shell
_build/default/rel/feedhack/bin/feedhack eval 'io:format("~ts~n",[[257]]).'
ok
```
