### PR TITLE
Redirect werl to erl.exe on windows ps templates, fix CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,8 +15,8 @@ jobs:
 
     strategy:
       matrix:
-        otp_version: [23, 24, 26]
-        os: [ubuntu-20.04] # latest only runs >= 24.2
+        otp_version: [26, 27, 28]
+        os: [ubuntu-latest] # latest only runs >= 24.2
 
     container:
       image: erlang:${{ matrix.otp_version }}

--- a/.github/workflows/shelltest.yml
+++ b/.github/workflows/shelltest.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         # TODO: make a batch of tests that runs on nodetool rather
         #       than the new connectivity mechanism
-        otp_version: [25, 26]
+        otp_version: [26, 27, 28]
         os: [ubuntu-latest] # latest only runs >= 24.2
 
     steps:

--- a/.github/workflows/wintest.yml
+++ b/.github/workflows/wintest.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        otp_version: [24, 25, 26]
+        otp_version: [26, 27, 28]
         os: [windows-latest]
 
     steps:

--- a/priv/templates/extended_bin_windows_ps
+++ b/priv/templates/extended_bin_windows_ps
@@ -62,7 +62,8 @@ $service_name = "${rel_name}_${rel_vsn}"
 $nodetool = "$rootdir\bin\nodetool"
 
 $bindir = "$erts_dir\bin"
-$werl = "$bindir\werl.exe"
+# since OTP-26, werl.exe is just erl.exe, so link it directly
+$werl = "$bindir\erl.exe"
 $erl = "$bindir\erl.exe"
 $erlsrv = "$bindir\erlsrv.exe"
 $escript = "$bindir\escript.exe"

--- a/priv/templates/psutil
+++ b/priv/templates/psutil
@@ -17,13 +17,13 @@ function Find-ERTS()
 
     # Get the ERTS dir from erl
     $erl = (Get-Command erl).source
-    $erl_root = & $erl -boot no_dot_erlang -noshell -eval 'io:format(\"~s\", [filename:nativename(code:root_dir())]), halt().'
+    $erl_root = & $erl -boot no_dot_erlang -noshell -eval 'io:format("~s", [filename:nativename(code:root_dir())]), halt().'
     if (Test-Path "$erl_root\erts-$Vsn") {
         return @($erl_root, "$erl_root\erts-$Vsn")
     }
 
     # Expected $vsn but not found, get ERTS version installed
-    $erts_vsn = & $erl -boot no_dot_erlang -noshell -eval 'io:format(\"~s\", [erlang:system_info(version)]), halt().'
+    $erts_vsn = & $erl -boot no_dot_erlang -noshell -eval 'io:format("~s", [erlang:system_info(version)]), halt().'
     if (!(Test-Path "$erl_root\erts-$erts_vsn")) {
         Write-Error "Can not run the release. There is no ERTS bundled with the release or found on the system."
         # Terminates here due to $ErrorActionPreference = "Stop"

--- a/shelltests/wintest.ps1
+++ b/shelltests/wintest.ps1
@@ -24,11 +24,12 @@ mkdir $rebar3_dir | Out-Null
 # Clone latest rebar3 and build with relx as a checkout
 Push-Location $rebar3_dir
 & git clone "https://github.com/erlang/rebar3" .
-Remove-Item -Path "vendor\relx\*" -Recurse -Force
-Copy-Item -Path "$PSScriptRoot\..\..\relx\*" -Destination "vendor\relx" -Recurse -Exclude ".git" #| Out-Null
-#mkdir _checkouts | Out-Null
-#New-Item -ItemType SymbolicLink -Path "_checkouts\relx" -Target "$PSScriptRoot\..\..\relx" | Out-Null
-#(Get-Content rebar.config) -replace 'relx(.*)build/default/lib/', 'relx$1checkouts' | Set-Content rebar.config -Encoding ASCII
+Remove-Item -Path "vendor\relx\src\*" -Recurse -Force
+Remove-Item -Path "vendor\relx\priv\*" -Recurse -Force
+Remove-Item -Path "vendor\relx\rebar*" -Force
+Copy-Item -Path "$PSScriptRoot\..\..\relx\src\*" -Destination "vendor\relx\src" -Recurse | Out-Null
+Copy-Item -Path "$PSScriptRoot\..\..\relx\priv\*" -Destination "vendor\relx\priv" -Recurse | Out-Null
+Copy-Item -Path "$PSScriptRoot\..\..\relx\rebar*" -Destination "vendor\relx" -Recurse #| Out-Null
 cmd /c bootstrap.bat
 Pop-Location
 ""
@@ -63,12 +64,18 @@ if ($LASTEXITCODE -ne 0) {
 }
 ""
 
+Get-Process | Out-String -Stream
+Get-Service -Name powershell_release_0.1.0 | Out-String -Stream
+
 "*** Start service"
 & ".\$release.ps1" start
 if ($LASTEXITCODE -ne 0) {
     Write-Error "Failed to start service"
 }
 ""
+
+Get-Process | Out-String -Stream
+Get-Service -Name powershell_release_0.1.0 | Out-String -Stream
 
 "*** Ping service"
 & ".\$release.ps1" ping

--- a/shelltests/wintest.ps1
+++ b/shelltests/wintest.ps1
@@ -24,9 +24,11 @@ mkdir $rebar3_dir | Out-Null
 # Clone latest rebar3 and build with relx as a checkout
 Push-Location $rebar3_dir
 & git clone "https://github.com/erlang/rebar3" .
-mkdir _checkouts | Out-Null
-New-Item -ItemType SymbolicLink -Path "_checkouts\relx" -Target "$PSScriptRoot\..\..\relx" | Out-Null
-(Get-Content rebar.config) -replace 'relx(.*)build/default/lib/', 'relx$1checkouts' | Set-Content rebar.config -Encoding ASCII
+Remove-Item -Path "vendor\relx\*" -Recurse -Force
+Copy-Item -Path "$PSScriptRoot\..\..\relx\*" -Destination "vendor\relx" -Recurse -Exclude ".git" #| Out-Null
+#mkdir _checkouts | Out-Null
+#New-Item -ItemType SymbolicLink -Path "_checkouts\relx" -Target "$PSScriptRoot\..\..\relx" | Out-Null
+#(Get-Content rebar.config) -replace 'relx(.*)build/default/lib/', 'relx$1checkouts' | Set-Content rebar.config -Encoding ASCII
 cmd /c bootstrap.bat
 Pop-Location
 ""

--- a/src/relx.erl
+++ b/src/relx.erl
@@ -127,6 +127,10 @@ build_tar(RelName, Apps, State) when is_atom(RelName) ->
     build_tar_(RealizedRelease, State),
     {ok, RealizedRelease}.
 
+%% Ignore Dialyzer warnings on this, `no_warn_sasl` is a valid option
+%% but the `systools:make_relup/4` spec is outdated and this causes
+%% warning as late as OTP-28, and all calls in the chain fail analysis in turn.
+-dialyzer({nowarn_function, [build_relup/4]}).
 -spec build_relup(rlx_release:name(), rlx_release:vsn(), rlx_release:vsn(), rlx_config:t() | rlx_state:t())
                  -> {ok, rlx_state:t()} | {error, term()}.
 build_relup(RelName, ToVsn, UpFromVsn, Config) when is_list(Config) ->

--- a/src/rlx_relup.erl
+++ b/src/rlx_relup.erl
@@ -6,6 +6,10 @@
 -include("relx.hrl").
 -include("rlx_log.hrl").
 
+%% Ignore Dialyzer warnings on this, `no_warn_sasl` is a valid option
+%% but the `systools:make_relup/4` spec is outdated and this causes
+%% warning as late as OTP-28, and all calls in the chain fail analysis in turn.
+-dialyzer({nowarn_function, [do/4, make_upfrom_script/4]}).
 -spec do(atom(), string(), string() | undefined, rlx_state:t()) -> {ok, rlx_state:t()} | relx:error().
 do(RelName, ToVsn, undefined, State) ->
     OutputDir = rlx_state:base_output_dir(State),


### PR DESCRIPTION
Since OTP-26, which is now our earlier major version supported, werl.exe just no longer really exists and we use erl.exe instead. The other windows template file does dynamic matching but ps stuff is a bit more complex and I no longer have a windows computer to test this on, so I'm going for the safest fix at the time.

Addresses https://github.com/erlware/relx/issues/955