### PR TITLE
Fix OTP29 compilation

### DIFF
--- a/src/rlx_assemble.erl
+++ b/src/rlx_assemble.erl
@@ -732,7 +732,7 @@ maybe_check_for_undefined_functions_(State, Release) ->
             %% without adding the erts application there will be warnings about 
             %% missing functions from the preloaded modules even though they 
             %% are in the runtime.
-            ErtsApp = code:lib_dir(erts, ebin),
+            ErtsApp = filename:join(code:lib_dir(erts), "ebin"),
 
             %% xref library path is what is searched for functions used by the 
             %% project apps. 

--- a/src/rlx_util.erl
+++ b/src/rlx_util.erl
@@ -159,11 +159,12 @@ is_error(_) ->
 render(Template, Data) when is_list(Template) ->
     render(rlx_util:to_binary(Template), Data);
 render(Template, Data) when is_binary(Template) ->
-    case catch bbmustache:render(Template, Data,
+    try bbmustache:render(Template, Data,
                                  [{key_type, atom},
                                   {escape_fun, fun(X) -> X end}]) of
-        Bin when is_binary(Bin) -> {ok, Bin};
-        _ -> {error, render_failed}
+        Bin when is_binary(Bin) -> {ok, Bin}
+    catch
+        _:_ -> {error, render_failed}
     end.
 
 load_file(Files, escript, Name) ->


### PR DESCRIPTION
Deprecated `catch` and `code:lib_dir/2`